### PR TITLE
Add fuzzing to the tests that were not previously fuzzed

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -40,9 +40,9 @@ stack_allocation = true   # Improves allocation of stack slots for variables.
 
 [profile.debug]
 # Make things chattier when debugging in case of test failures, giving us more
-# information with which to debug the issue. At this level, stack traces for all
-# tests are displayed, and setup traces for failing tests are displayed.
-verbosity = 4
+# information with which to debug the issue. At this level, stack traces and 
+# setup traces for failing tests are displayed.
+verbosity = 3
 
 # === Test All Profile ========================================================
 

--- a/src/Semaphore.sol
+++ b/src/Semaphore.sol
@@ -3,13 +3,9 @@ pragma solidity ^0.8.10;
 
 import {Verifier as SemaphoreVerifier} from "semaphore/base/Verifier.sol";
 import {IWorldID} from "./interfaces/IWorldID.sol";
+import {ITreeVerifier} from "./interfaces/ITreeVerifier.sol";
 import {SemaphoreCore} from "semaphore/base/SemaphoreCore.sol";
 import {SemaphoreGroups} from "semaphore/base/SemaphoreGroups.sol";
-import {
-    IncrementalBinaryTree,
-    IncrementalTreeData
-} from "@zk-kit/incremental-merkle-tree.sol/contracts/IncrementalBinaryTree.sol";
-import {Verifier as MerkleTreeVerifier} from "./generated/TreeVerifier.sol";
 
 /// @title WorldID Identity Manager
 /// @author Worldcoin
@@ -92,7 +88,7 @@ contract Semaphore is IWorldID, SemaphoreCore {
     ///////////////////////////////////////////////////////////////////////////////
 
     /// @notice The verifier instance needed for verifying batch identity insertions.
-    MerkleTreeVerifier private merkleTreeVerifier = new MerkleTreeVerifier();
+    ITreeVerifier private merkleTreeVerifier;
 
     /// @notice The verifier instance needed for operating within the semaphore protocol.
     SemaphoreVerifier private semaphoreVerifier = new SemaphoreVerifier();
@@ -105,8 +101,9 @@ contract Semaphore is IWorldID, SemaphoreCore {
     ///
     /// @param initialRoot The initial value for the `latestRoot` in the contract. When deploying
     ///        this should be set to the root of an empty tree.
-    constructor(uint256 initialRoot) {
+    constructor(uint256 initialRoot, ITreeVerifier merkleTreeVerifier_) {
         latestRoot = initialRoot;
+        merkleTreeVerifier = merkleTreeVerifier_;
     }
 
     ///////////////////////////////////////////////////////////////////////////////

--- a/src/Semaphore.sol
+++ b/src/Semaphore.sol
@@ -7,8 +7,6 @@ import {ITreeVerifier} from "./interfaces/ITreeVerifier.sol";
 import {SemaphoreCore} from "semaphore/base/SemaphoreCore.sol";
 import {SemaphoreGroups} from "semaphore/base/SemaphoreGroups.sol";
 
-import "forge-std/Console.sol";
-
 /// @title WorldID Identity Manager
 /// @author Worldcoin
 /// @notice An implementation of a batch-based identity manager for the WorldID protocol.

--- a/src/Semaphore.sol
+++ b/src/Semaphore.sol
@@ -7,6 +7,8 @@ import {ITreeVerifier} from "./interfaces/ITreeVerifier.sol";
 import {SemaphoreCore} from "semaphore/base/SemaphoreCore.sol";
 import {SemaphoreGroups} from "semaphore/base/SemaphoreGroups.sol";
 
+import "forge-std/Console.sol";
+
 /// @title WorldID Identity Manager
 /// @author Worldcoin
 /// @notice An implementation of a batch-based identity manager for the WorldID protocol.

--- a/src/interfaces/ITreeVerifier.sol
+++ b/src/interfaces/ITreeVerifier.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+/// @title Tree Verifier Interface
+/// @author Worldcoin
+/// @notice An interface representing a merkle tree verifier.
+interface ITreeVerifier {
+    /// @notice Verifies the provided proof data for the provided public inputs.
+    ///
+    /// @param a The first G1Point of the proof (ar).
+    /// @param b The G2Point for the proof (bs).
+    /// @param c The second G1Point of the proof (kr).
+    /// @param input The public inputs to the function, reduced such that it is a member of the
+    ///              field `Fr` where `r` is `SNARK_SCALAR_FIELD`.
+    ///
+    /// @return _ True if the proof verifies successfully, false otherwise.
+    /// @custom:reverts string If the proof elements are not < `PRIME_Q` or if the `input` is not
+    ///                 less than `SNARK_SCALAR_FIELD`.
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[1] memory input
+    ) external view returns (bool);
+}

--- a/src/test/Semaphore.t.sol
+++ b/src/test/Semaphore.t.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.10;
 import {Vm} from "forge-std/Vm.sol";
 import {Test} from "forge-std/Test.sol";
 
-import {Semaphore} from "../Semaphore.sol";
+import {Semaphore, ITreeVerifier} from "../Semaphore.sol";
+import {Verifier as TreeVerifier} from "./mock/TreeVerifier.sol";
 
 import "forge-std/console.sol";
 
@@ -57,7 +58,8 @@ contract SemaphoreTest is Test {
 
     /// @notice This runs before every test.
     function setUp() public {
-        semaphore = new Semaphore(preRoot);
+        TreeVerifier verifier = new TreeVerifier();
+        semaphore = new Semaphore(preRoot, ITreeVerifier(address(verifier)));
 
         hevm.label(address(this), "Sender");
         hevm.label(address(semaphore), "Semaphore");
@@ -148,7 +150,8 @@ contract SemaphoreTest is Test {
     ///         root.
     function testCannotRegisterIdentitiesWithOutdatedRoot() public {
         // Setup
-        Semaphore localSemaphore = new Semaphore(uint256(0));
+        TreeVerifier verifier = new TreeVerifier();
+        Semaphore localSemaphore = new Semaphore(uint256(0), ITreeVerifier((verifier)));
         bytes memory expectedError =
             abi.encodeWithSelector(Semaphore.NotLatestRoot.selector, preRoot, uint256(0));
         vm.expectRevert(expectedError);

--- a/src/test/mock/SimpleVerifier.sol
+++ b/src/test/mock/SimpleVerifier.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import {ITreeVerifier} from "../../interfaces/ITreeVerifier.sol";
+
+/// @title Simple Verifier
+/// @author Worldcoin
+/// @notice A dumb verifier to make it easy to fuzz test successes and failures.
+contract SimpleVerifier is ITreeVerifier {
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[1] memory input
+    ) external pure override returns (bool) {
+        return SimpleVerify.verifyProof(a, b, c, input);
+    }
+}
+
+library SimpleVerify {
+    function isValidInput(uint256 a) public pure returns (bool) {
+        return a % 2 == 0;
+    }
+
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[1] memory input
+    ) public pure returns (bool) {
+        delete b;
+        delete c;
+        delete input;
+        return isValidInput(a[0]);
+    }
+
+    function calculateInputHash(
+        uint32 startIndex,
+        uint256 preRoot,
+        uint256 postRoot,
+        uint256[] calldata identityCommitments
+    ) public pure returns (bytes32 hash) {
+        bytes memory bytesToHash =
+            abi.encodePacked(startIndex, preRoot, postRoot, identityCommitments);
+
+        hash = keccak256(bytesToHash);
+    }
+}

--- a/src/test/mock/TreeVerifier.sol
+++ b/src/test/mock/TreeVerifier.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: AML
+//
+// Copyright 2017 Christian Reitwiessner
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+// 2019 OKIMS
+
+pragma solidity ^0.8.10;
+
+// Worldcoin Modification Begin
+import {ITreeVerifier} from "../../interfaces/ITreeVerifier.sol";
+// Worldcoin Modification End
+
+library Pairing {
+    uint256 constant PRIME_Q =
+        21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    struct G1Point {
+        uint256 X;
+        uint256 Y;
+    }
+
+    // Encoding of field elements is: X[0] * z + X[1]
+    struct G2Point {
+        uint256[2] X;
+        uint256[2] Y;
+    }
+
+    /*
+     * @return The negation of p, i.e. p.plus(p.negate()) should be zero.
+     */
+    function negate(G1Point memory p) internal pure returns (G1Point memory) {
+        // The prime q in the base field F_q for G1
+        if (p.X == 0 && p.Y == 0) {
+            return G1Point(0, 0);
+        } else {
+            return G1Point(p.X, PRIME_Q - (p.Y % PRIME_Q));
+        }
+    }
+
+    /*
+     * @return The sum of two points of G1
+     */
+    function plus(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
+        uint256[4] memory input;
+        input[0] = p1.X;
+        input[1] = p1.Y;
+        input[2] = p2.X;
+        input[3] = p2.Y;
+        bool success;
+
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success
+            case 0 { invalid() }
+        }
+
+        require(success, "pairing-add-failed");
+    }
+
+    /*
+     * @return The product of a point on G1 and a scalar, i.e.
+     *         p == p.scalar_mul(1) and p.plus(p) == p.scalar_mul(2) for all
+     *         points p.
+     */
+    function scalar_mul(G1Point memory p, uint256 s) internal view returns (G1Point memory r) {
+        uint256[3] memory input;
+        input[0] = p.X;
+        input[1] = p.Y;
+        input[2] = s;
+        bool success;
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success
+            case 0 { invalid() }
+        }
+        require(success, "pairing-mul-failed");
+    }
+
+    /* @return The result of computing the pairing check
+     *         e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+     *         For example,
+     *         pairing([P1(), P1().negate()], [P2(), P2()]) should return true.
+     */
+    function pairing(
+        G1Point memory a1,
+        G2Point memory a2,
+        G1Point memory b1,
+        G2Point memory b2,
+        G1Point memory c1,
+        G2Point memory c2,
+        G1Point memory d1,
+        G2Point memory d2
+    ) internal view returns (bool) {
+        G1Point[4] memory p1 = [a1, b1, c1, d1];
+        G2Point[4] memory p2 = [a2, b2, c2, d2];
+        uint256 inputSize = 24;
+        uint256[] memory input = new uint256[](inputSize);
+
+        for (uint256 i = 0; i < 4; i++) {
+            uint256 j = i * 6;
+            input[j + 0] = p1[i].X;
+            input[j + 1] = p1[i].Y;
+            input[j + 2] = p2[i].X[0];
+            input[j + 3] = p2[i].X[1];
+            input[j + 4] = p2[i].Y[0];
+            input[j + 5] = p2[i].Y[1];
+        }
+
+        uint256[1] memory out;
+        bool success;
+
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            success :=
+                staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            // Use "invalid" to make gas estimation work
+            switch success
+            case 0 { invalid() }
+        }
+
+        require(success, "pairing-opcode-failed");
+
+        return out[0] != 0;
+    }
+}
+
+// Worldcoin Modification Begin
+contract Verifier is ITreeVerifier {
+    // Worldcoin Modification End
+    using Pairing for *;
+
+    uint256 constant SNARK_SCALAR_FIELD =
+        21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    uint256 constant PRIME_Q =
+        21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+    struct VerifyingKey {
+        Pairing.G1Point alfa1;
+        Pairing.G2Point beta2;
+        Pairing.G2Point gamma2;
+        Pairing.G2Point delta2;
+        Pairing.G1Point[2] IC;
+    }
+
+    struct Proof {
+        Pairing.G1Point A;
+        Pairing.G2Point B;
+        Pairing.G1Point C;
+    }
+
+    function verifyingKey() internal pure returns (VerifyingKey memory vk) {
+        vk.alfa1 = Pairing.G1Point(
+            uint256(20511579680485128435968492529477986054143624895130267136299969518428310397583),
+            uint256(12019183066292893271875993042849002846200951499939001731947162535134268084362)
+        );
+        vk.beta2 = Pairing.G2Point(
+            [
+                uint256(2089676812529243142469162728618839638435359905327620749498509643225358128912),
+                uint256(7904895411458501455966830052510986257464308709496849793787095953158487122304)
+            ],
+            [
+                uint256(16797507473745040958844202637614442452840135422747682014230743717837892841028),
+                uint256(9473339184494274655577348453617870794049644188434434075522198845582264704106)
+            ]
+        );
+        vk.gamma2 = Pairing.G2Point(
+            [
+                uint256(18857088877831991395879893788315426632011108011495870716514470189262586374610),
+                uint256(4389555201093468693636136029755231137723360019751348191879841133076369674917)
+            ],
+            [
+                uint256(13362381349504071289893854895447856933068773897799959938583933929038383825378),
+                uint256(16986196626872063819265139926040651012192136018211263012697320066417863414017)
+            ]
+        );
+        vk.delta2 = Pairing.G2Point(
+            [
+                uint256(12313730183775831354894919682887228076436409607715148516704569441139088930688),
+                uint256(2552231658739687496972790410151668919124141665121206694028316488936580642349)
+            ],
+            [
+                uint256(2364937275864597293303184061344064915914201762511884649994290705518114506818),
+                uint256(14782994374673117770861880065787271579362240800510712289723727525292605454935)
+            ]
+        );
+        vk.IC[0] = Pairing.G1Point(
+            uint256(18444671359917035747943528843359189897401309276553441532102135228117744117540),
+            uint256(14807363264404528745778014983613754484255874843241911076089872533921692657040)
+        );
+        vk.IC[1] = Pairing.G1Point(
+            uint256(11483784651604377113147887759057304308126467247011330592789526483132957880096),
+            uint256(15913982624926250684711060136269733377890569322844166112237620732524677990300)
+        );
+    }
+
+    /*
+     * @returns Whether the proof is valid given the hardcoded verifying key
+     *          above and the public inputs
+     */
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[1] memory input
+    ) public view returns (bool r) {
+        Proof memory proof;
+        proof.A = Pairing.G1Point(a[0], a[1]);
+        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+        proof.C = Pairing.G1Point(c[0], c[1]);
+
+        VerifyingKey memory vk = verifyingKey();
+
+        // Compute the linear combination vk_x
+        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+
+        // Make sure that proof.A, B, and C are each less than the prime q
+        require(proof.A.X < PRIME_Q, "verifier-aX-gte-prime-q");
+        require(proof.A.Y < PRIME_Q, "verifier-aY-gte-prime-q");
+
+        require(proof.B.X[0] < PRIME_Q, "verifier-bX0-gte-prime-q");
+        require(proof.B.Y[0] < PRIME_Q, "verifier-bY0-gte-prime-q");
+
+        require(proof.B.X[1] < PRIME_Q, "verifier-bX1-gte-prime-q");
+        require(proof.B.Y[1] < PRIME_Q, "verifier-bY1-gte-prime-q");
+
+        require(proof.C.X < PRIME_Q, "verifier-cX-gte-prime-q");
+        require(proof.C.Y < PRIME_Q, "verifier-cY-gte-prime-q");
+
+        // Make sure that every input is less than the snark scalar field
+        for (uint256 i = 0; i < input.length; i++) {
+            require(input[i] < SNARK_SCALAR_FIELD, "verifier-gte-snark-scalar-field");
+            vk_x = Pairing.plus(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
+        }
+
+        vk_x = Pairing.plus(vk_x, vk.IC[0]);
+
+        return Pairing.pairing(
+            Pairing.negate(proof.A),
+            proof.B,
+            vk.alfa1,
+            vk.beta2,
+            vk_x,
+            vk.gamma2,
+            proof.C,
+            vk.delta2
+        );
+    }
+}


### PR DESCRIPTION
This PR adds fuzzing to the tests that could be fuzzed but were not previously being fuzzed. It also ports the Solidity-side changes from #27 and cleans that up.

Closes #21.