### PR TITLE
Update the deploy scripts to handle upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ remappings.txt
 node_modules
 .env
 mtb/
+.deploy-config.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,6 @@ lib/
 out/
 cache/
 mtb/
-.deploy-config.json
 
 # Solidity
 *.sol

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@ lib/
 out/
 cache/
 mtb/
+.deploy-config.json
 
 # Solidity
 *.sol

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,37 @@
+# By default we want to build.
 all: install build
+
+# ===== Basic Development Rules =======================================================================================
+
 # Install forge dependencies (not needed if submodules are already initialized).
 install:; forge install && npm install
+
 # Build contracts and inject the Poseidon library.
 build:; forge build
+
 # Run tests, with debug information and gas reports.
 test:; FOUNDRY_PROFILE=debug forge test
+
+# ===== Profiling Rules ===============================================================================================
+
 # Benchmark the tests.
 bench:; FOUNDRY_PROFILE=bench forge test --gas-report --no-match-test testCannotRegisterIfProofIncorrect
+
 # Snapshot the current test usages.
 snapshot:; FOUNDRY_PROFILE=bench forge snapshot --no-match-test testCannotRegisterIfProofIncorrect
+
+# ===== Deployment Rules ==============================================================================================
+
+# Deploy contracts
+deploy: install build; node --no-warnings scripts/deploy.js deploy
+
+# Upgrade contracts
+upgrade: install build; node --no-warnings scripts/deploy.js upgrade
+
+# ===== Utility Rules =================================================================================================
+
 # Format the solidity code.
 format:; forge fmt; npx prettier --write .
+
 # Update forge dependencies.
 update:; forge update
-# Deploy contracts
-deploy: install build; node --no-warnings scripts/deploy.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@zk-kit/identity": "^1.4.1",
                 "@zk-kit/protocols": "^1.11.0",
                 "circomlibjs": "0.0.8",
+                "commander": "^10.0.0",
                 "dotenv": "^16.0.0",
                 "ethers": "^5.7.2",
                 "ora": "^6.1.0",
@@ -1564,11 +1565,11 @@
             "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
         },
         "node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+            "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
             "engines": {
-                "node": ">= 12"
+                "node": ">=14"
             }
         },
         "node_modules/concat-map": {
@@ -4165,6 +4166,14 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/solc/node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/solc/node_modules/semver": {
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -6287,9 +6296,9 @@
             "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
         },
         "commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+            "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -8288,6 +8297,11 @@
                 "tmp": "0.0.33"
             },
             "dependencies": {
+                "commander": {
+                    "version": "8.3.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+                    "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+                },
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
         "url": "https://github.com/worldcoin/world-id-contracts/issues"
     },
     "dependencies": {
-        "ethers": "^5.7.2",
         "@zk-kit/identity": "^1.4.1",
         "@zk-kit/protocols": "^1.11.0",
         "circomlibjs": "0.0.8",
+        "commander": "^10.0.0",
         "dotenv": "^16.0.0",
+        "ethers": "^5.7.2",
         "ora": "^6.1.0",
         "solc": "0.8.17"
     },

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -438,6 +438,20 @@ async function getWallet(config) {
     config.wallet = new Wallet(config.privateKey, config.provider);
 }
 
+async function getUpgradeTargetAddress(config) {
+    config.upgradeTargetAddress = config.identityManagerContractAddress;
+    if (!config.upgradeTargetAddress) {
+        config.upgradeTargetAddress = process.env.UPGRADE_TARGET_ADDRESS;
+    }
+    if (!config.upgradeTargetAddress) {
+        config.upgradeTargetAddress = await ask(`Enter upgrade target address: `);
+    }
+    if (!config.upgradeTargetAddress) {
+        console.error("Unable to detect upgrade target address. Aborting...")
+        process.exit(1);
+    }
+}
+
 async function buildDeploymentActionPlan(plan, config) {
     dotenv.config();
 
@@ -459,12 +473,15 @@ async function buildUpgradeActionPlan(plan, config) {
     await getProvider(config);
     await getWallet(config);
 
+    await getUpgradeTargetAddress(config);
+
     // TODO [Ara]
-    //   1. Obtain the address at which to upgrade.
-    //   2. Work out _how_ to obtain the upgrade params from the user. Do I just hardcode some to
-    //      start with? Probably.
-    //   3. Work out if it makes sense to make it modular. Probably not. It's just deploying the
-    //      test.
+    //   0. Make the existing config be saved and reused between runs.
+    //   1. Obtain the address at which to upgrade (cannot default, but can use env).
+    //   2. Ask the user for the path to the contract ABI specification.
+    //   3. Ask the user to provide the name of the upgrade function (or leave blank to default).
+    //   4. Ask the user for each argument to provide the call data (or default).
+    //   5. Make the upgrade call.
 }
 
 /** Builds a plan using the provided function and then executes the plan.

--- a/src/WorldIDIdentityManagerImplV1.sol
+++ b/src/WorldIDIdentityManagerImplV1.sol
@@ -185,6 +185,7 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
     /// @custom:reverts string If called more than once at the same initalisation number.
     function initialize(uint256 initialRoot, ITreeVerifier merkleTreeVerifier_)
         public
+        virtual 
         reinitializer(1)
     {
         // First, ensure that all of the parent contracts are initialised.

--- a/src/WorldIDIdentityManagerImplV1.sol
+++ b/src/WorldIDIdentityManagerImplV1.sol
@@ -185,7 +185,7 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
     /// @custom:reverts string If called more than once at the same initalisation number.
     function initialize(uint256 initialRoot, ITreeVerifier merkleTreeVerifier_)
         public
-        virtual 
+        virtual
         reinitializer(1)
     {
         // First, ensure that all of the parent contracts are initialised.

--- a/src/test/WorldIDIdentityManager.t.sol
+++ b/src/test/WorldIDIdentityManager.t.sol
@@ -316,7 +316,7 @@ contract WorldIDIdentityManagerTest is Test {
     function testCanUpgradeImplementationWithCall() public {
         // Setup
         WorldIDIdentityManagerImplMock mockUpgrade = new WorldIDIdentityManagerImplMock();
-        bytes memory initCall = abi.encodeCall(WorldIDIdentityManagerImplMock.initializeV2, (320));
+        bytes memory initCall = abi.encodeCall(WorldIDIdentityManagerImplMock.initialize, (320));
         bytes memory upgradeCall =
             abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(mockUpgrade), initCall));
 
@@ -329,7 +329,7 @@ contract WorldIDIdentityManagerTest is Test {
         // Setup
         vm.assume(naughty != address(this) && naughty != address(0x0));
         WorldIDIdentityManagerImplMock mockUpgrade = new WorldIDIdentityManagerImplMock();
-        bytes memory initCall = abi.encodeCall(WorldIDIdentityManagerImplMock.initializeV2, (320));
+        bytes memory initCall = abi.encodeCall(WorldIDIdentityManagerImplMock.initialize, (320));
         bytes memory upgradeCall =
             abi.encodeCall(UUPSUpgradeable.upgradeToAndCall, (address(mockUpgrade), initCall));
         vm.prank(naughty);

--- a/src/test/mock/WorldIDIdentityManagerImplMock.sol
+++ b/src/test/mock/WorldIDIdentityManagerImplMock.sol
@@ -6,10 +6,19 @@ import {WorldIDIdentityManagerImplV1} from "../../WorldIDIdentityManagerImplV1.s
 /// @title WorldID Identity Manager Implementation Mock
 /// @author Worldcoin
 contract WorldIDIdentityManagerImplMock is WorldIDIdentityManagerImplV1 {
-    uint32 public someMoreData;
+    uint32 internal _someMoreData;
+
+    constructor() {
+        _disableInitializers();
+    }
 
     /// @notice Used to initialize the new things in the upgraded contract.
-    function initializeV2(uint32 data) public virtual reinitializer(2) {
-        someMoreData = data;
+    function initialize(uint32 data) public virtual reinitializer(2) {
+        _someMoreData = data;
+    }
+
+    /// @notice Obtains the value of `someMoreData`.
+    function someMoreData() public view returns (uint32) {
+        return _someMoreData;
     }
 }


### PR DESCRIPTION
Like it says on the tin. It also adds configuration storage to make constant redeploying while working with signup sequencer a bit less painful.

Closes #35.