### PR TITLE
Allow runs of zeroes for identities

### DIFF
--- a/src/WorldIDIdentityManagerImplV1.sol
+++ b/src/WorldIDIdentityManagerImplV1.sol
@@ -136,8 +136,9 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
 
     /// @notice Thrown when one or more of the identity commitments to be inserted is invalid.
     ///
-    /// @param commitment The invalid commitment.
-    error InvalidCommitment(uint256 commitment);
+    /// @param index The index in the array of identity commitments where the invalid commitment was
+    ///        found.
+    error InvalidCommitment(uint256 index);
 
     /// @notice Thrown when the provided proof cannot be verified for the accompanying inputs.
     error ProofValidationFailure();
@@ -199,8 +200,6 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
         // Say that the contract is initialized.
         _initialized = true;
     }
-
-    // Todo [Ara] Work out if we should guard functionality on being inited.
 
     /// @notice Responsible for initialising all of the supertypes of this contract.
     /// @dev Must be called exactly once.
@@ -374,6 +373,8 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
 
     /// @notice Validates an array of identity commitments, reverting if it finds one that is
     ///         invalid or has not been reduced.
+    /// @dev Identities are not valid if they are all zeroes or if an identity is a non-zero element
+    ///      that occurs after a zero element in the array.
     ///
     /// @param identityCommitments The array of identity commitments to be validated.
     ///
@@ -386,13 +387,25 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
         view
         virtual
     {
+        bool previousIsValid = false;
+        uint256 previous = 0;
+
         for (uint256 i = 0; i < identityCommitments.length; ++i) {
             uint256 commitment = identityCommitments[i];
+            if (previousIsValid && previous == 0 && commitment != 0) {
+                revert InvalidCommitment(i);
+            }
             if (!isInputInReducedForm(commitment)) {
                 revert UnreducedElement(UnreducedElementType.IdentityCommitment, commitment);
             }
-            if (commitment == EMPTY_LEAF) {
-                revert InvalidCommitment(identityCommitments[i]);
+            if (i > 0) {
+                previousIsValid = true;
+                previous = commitment;
+            } else {
+                // The first iteration needs to be checked separately.
+                if (commitment == 0) {
+                    revert InvalidCommitment(i);
+                }
             }
         }
     }

--- a/src/WorldIDIdentityManagerImplV1.sol
+++ b/src/WorldIDIdentityManagerImplV1.sol
@@ -387,26 +387,17 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
         view
         virtual
     {
-        bool previousIsValid = false;
-        uint256 previous = 0;
+        bool previousIsZero = false;
 
         for (uint256 i = 0; i < identityCommitments.length; ++i) {
             uint256 commitment = identityCommitments[i];
-            if (previousIsValid && previous == 0 && commitment != 0) {
+            if (previousIsZero && commitment != 0) {
                 revert InvalidCommitment(i);
             }
             if (!isInputInReducedForm(commitment)) {
                 revert UnreducedElement(UnreducedElementType.IdentityCommitment, commitment);
             }
-            if (i > 0) {
-                previousIsValid = true;
-                previous = commitment;
-            } else {
-                // The first iteration needs to be checked separately.
-                if (commitment == 0) {
-                    revert InvalidCommitment(i);
-                }
-            }
+            previousIsZero = commitment == 0;
         }
     }
 

--- a/src/WorldIDIdentityManagerImplV1.sol
+++ b/src/WorldIDIdentityManagerImplV1.sol
@@ -373,8 +373,8 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
 
     /// @notice Validates an array of identity commitments, reverting if it finds one that is
     ///         invalid or has not been reduced.
-    /// @dev Identities are not valid if they are all zeroes or if an identity is a non-zero element
-    ///      that occurs after a zero element in the array.
+    /// @dev Identities are not valid if an identity is a non-zero element that occurs after a zero
+    ///      element in the array.
     ///
     /// @param identityCommitments The array of identity commitments to be validated.
     ///

--- a/src/WorldIDIdentityManagerImplV1.sol
+++ b/src/WorldIDIdentityManagerImplV1.sol
@@ -391,13 +391,13 @@ contract WorldIDIdentityManagerImplV1 is OwnableUpgradeable, UUPSUpgradeable, IW
 
         for (uint256 i = 0; i < identityCommitments.length; ++i) {
             uint256 commitment = identityCommitments[i];
-            if (previousIsZero && commitment != 0) {
+            if (previousIsZero && commitment != EMPTY_LEAF) {
                 revert InvalidCommitment(i);
             }
             if (!isInputInReducedForm(commitment)) {
                 revert UnreducedElement(UnreducedElementType.IdentityCommitment, commitment);
             }
-            previousIsZero = commitment == 0;
+            previousIsZero = commitment == EMPTY_LEAF;
         }
     }
 

--- a/src/test/WorldIDIdentityManager.t.sol
+++ b/src/test/WorldIDIdentityManager.t.sol
@@ -612,17 +612,14 @@ contract WorldIDIdentityManagerTest is Test {
             invalidCommitments[i] = i + 1;
         }
         invalidCommitments[invalidPosition] = 0x0;
-        uint256 errorIndex = 0;
-        if (invalidPosition != 0) {
-            errorIndex = invalidPosition + 1;
-        }
 
         bytes memory callData = abi.encodeCall(
             ManagerImpl.registerIdentities,
             (proof, initialRoot, startIndex, invalidCommitments, postRoot)
         );
-        bytes memory expectedError =
-            abi.encodeWithSelector(ManagerImpl.InvalidCommitment.selector, uint256(errorIndex));
+        bytes memory expectedError = abi.encodeWithSelector(
+            ManagerImpl.InvalidCommitment.selector, uint256(invalidPosition + 1)
+        );
 
         // Test
         assertCallFailsOn(identityManagerAddress, callData, expectedError);


### PR DESCRIPTION
Previously, an identity of zero anywhere in the array of identity commitments was considered to be a reason to fail. However, it turns out that we want to be able to submit batches that are padded out to the batch size using zeroes.

This commit changes the validation to only consider a run of all zeroes as invalid, or a non-zero identity occurring after a zero identity in the array.