### PR TITLE
Signup Sequencer Verifier

### DIFF
--- a/src/test/mock/SequencerVerifier.sol
+++ b/src/test/mock/SequencerVerifier.sol
@@ -8,6 +8,9 @@ import {ITreeVerifier} from "../../interfaces/ITreeVerifier.sol";
 /// @notice A verifier that matches the success conditions used by the mock prover service in the
 ///         signup sequencer.
 contract SequencerVerifier is ITreeVerifier {
+    uint256 internal constant SNARK_SCALAR_FIELD =
+        21888242871839275222246405745257275088548364400416034343698204186575808495617;
+
     function verifyProof(
         uint256[2] memory a,
         uint256[2][2] memory b,
@@ -16,6 +19,6 @@ contract SequencerVerifier is ITreeVerifier {
     ) external pure override returns (bool) {
         delete b;
         delete c;
-        return a[0] % 2 == 0 && a[1] == input[0];
+        return a[0] % 2 == 0 && a[1] % SNARK_SCALAR_FIELD == input[0];
     }
 }

--- a/src/test/mock/SequencerVerifier.sol
+++ b/src/test/mock/SequencerVerifier.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import {ITreeVerifier} from "../../interfaces/ITreeVerifier.sol";
+
+/// @title Sequencer Verifier
+/// @author Worldcoin
+/// @notice A verifier that matches the success conditions used by the mock prover service in the
+///         signup sequencer.
+contract SequencerVerifier is ITreeVerifier {
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[1] memory input
+    ) external pure override returns (bool) {
+        delete b;
+        delete c;
+        return a[0] % 2 == 0 && a[1] == input[0];
+    }
+}


### PR DESCRIPTION
This verifier mock checks the same condition used by the prover mock in the signup sequencer integration tests, thereby providing the means for an e2e test of the signup sequencer in those tests.

It does not depend on and is not depended on by https://github.com/worldcoin/signup-sequencer/pull/398, but contains the changes available in that PR as compiled JSON.