### PR TITLE
Make sure initial root has 66 chars

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -493,7 +493,7 @@ function computeRoot(depth) {
     result = poseidon([result, result]);
   }
 
-  return '0x' + result.toString(16);
+  return '0x0' + result.toString(16);
 }
 
 async function ensureInitialRoot(plan, config) {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -493,7 +493,25 @@ function computeRoot(depth) {
     result = poseidon([result, result]);
   }
 
-  return '0x0' + result.toString(16);
+  return formatToAddress(result.toString(16));
+}
+
+// Prepends 0x at the beginning
+// Prepends zeros to make a string with 66 characters
+function formatToAddress(str) {
+  let maxLength = 64;
+  let maxAddressLength = 66;
+  if (str.length > maxLength) {
+    console.error("Root address too long");
+    return;
+  }
+
+  var prefix = '0x';
+  while (prefix.length + str.length < maxAddressLength) {
+    prefix += '0';
+  }
+
+  return prefix + str;
 }
 
 async function ensureInitialRoot(plan, config) {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -496,22 +496,11 @@ function computeRoot(depth) {
   return formatToAddress(result.toString(16));
 }
 
-// Prepends 0x at the beginning
-// Prepends zeros to make a string with 66 characters
+// This function ensures the address string has correct format and 66 characters
+// E.g. 0x0818d46bf52298b034413f4a1a1c11594e7a7a3f6ae08cb43d1a2a230e1959ef
+// Prepends 0x and zeros to make a string with 66 characters
 function formatToAddress(str) {
-  let maxLength = 64;
-  let maxAddressLength = 66;
-  if (str.length > maxLength) {
-    console.error("Root address too long");
-    return;
-  }
-
-  var prefix = '0x';
-  while (prefix.length + str.length < maxAddressLength) {
-    prefix += '0';
-  }
-
-  return prefix + str;
+  return '0x' + str.padStart(64, '0');
 }
 
 async function ensureInitialRoot(plan, config) {


### PR DESCRIPTION
While testing deployment on the testnet, I discovered the `Deploy WorldID Identity Manager` step failed with `Could not communicate with the WorldID Identity Manager at ...`. The deployment succeeded, but the comparison of the last root value failed.

Example of values for failed step
```
latestRoot._hex    - 0x0918d46bf52d98b034413f4a1a1c41594e7a7a3f6ae08cb43d1a2a230e1959ef
config.initialRoot - 0x918d46bf52d98b034413f4a1a1c41594e7a7a3f6ae08cb43d1a2a230e1959ef
```

@kustosz pointed out it would be great if we were consistent with the size of roots. This PR unifies it.