### PR TITLE
verifier-add should deploy new verifier if needed

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1633,10 +1633,14 @@ async function buildVerifierActionPlan(plan, config, type) {
     await getTargetVerifierAddress(config);
   }
 
+  const isDelete = type === "disable";
   const isAddOrUpdate = (type === "add") || (type === "update");
   const shouldDeploy = config.targetVerifierAddress === undefined || config.targetVerifierAddress === "";
 
-  if (isAddOrUpdate && shouldDeploy) {
+  // We want to query the user for the type of verifier
+  // pretty much always, except if this script is being run with the verifier
+  // already deployed and we're doing an update or add
+  if ((isAddOrUpdate && shouldDeploy) || isDelete) {
     await getTypeOfVerifierToDeploy(config);
   }
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -760,6 +760,7 @@ async function deployIdentityManager(plan, config, insertLUTTargetField, updateL
     spinner.text = `Waiting for the WorldID Identity Manager deployment transaction (address: ${contract.address})...`;
     await contract.deployTransaction.wait();
     config.identityManagerContractAddress = contract.address;
+    config.routerInitialRoute = config.identityManagerContractAddress;
 
     // Verify that the deployment went correctly.
     spinner.text = `Verifying correct deployment of the WorldID Identity Manager...`;
@@ -966,6 +967,21 @@ async function getEnableStateBridge(config) {
   }
 }
 
+/** Gets the address of the IdentityManager contract to be modified at.
+ *
+ * @param {Object} config The configuration for the script.
+ * @returns {Promise<void>} The IdentityManager contract address might be written into the `config` object.
+*/
+async function getIdentityManagerContractAddress(config) {
+  if (!config.identityManagerContractAddress) {
+    config.identityManagerContractAddress = process.env.IDENTITY_MANAGER_CONTRACT_ADDRESS;
+  }
+
+  if (!config.identityManagerContractAddress) {
+    config.identityManagerContractAddress = await ask('Please provide the address of the IdentityManager (or leave blank if not needed): ');
+  }
+}
+
 /** Gets the address for the WorldID router to be modified at.
  *
  * @param {Object} config The configuration for the script.
@@ -993,13 +1009,26 @@ async function getLookupTableAddress(config) {
 
   if (!config.lookupTableAddress) {
     config.lookupTableAddress = await ask(
-      'Enter the address for the lookup table to add a verifier to: '
+      'Enter the address for the lookup table to add a verifier to (or leave blank to fetch from the identity manager contract): '
     );
   }
 
+  if (!config.lookupTableAddress && config.identityManagerContractAddress) {
+    const contract = new Contract(config.identityManagerContractAddress, IdentityManagerImpl.abi, config.provider);
+
+    if (config.typeOfVerifierToDeploy === "insert") {
+      config.lookupTableAddress = await contract.getRegisterIdentitiesVerifierLookupTableAddress();
+    } else if (config.typeOfVerifierToDeploy === "update") {
+      config.lookupTableAddress = await contract.getIdentityUpdateVerifierLookupTableAddress();
+    } else {
+      console.error('Invalid type of verifier to deploy');
+      process.exit(1);
+    }
+  }
+
   if (!config.lookupTableAddress) {
-    console.error('No address provided for the lookup table but one is required.');
-    process.exit();
+    console.error('No lookup table address provided & failed to acquire from the identity manager contract.');
+    process.exit(1);
   }
 }
 
@@ -1010,13 +1039,28 @@ async function getTargetVerifierAddress(config) {
 
   if (!config.targetVerifierAddress) {
     config.targetVerifierAddress = await ask(
-      'Enter the address for the verifier to add to the lookup table: '
+      'Enter the address for the verifier to add to the lookup table (or leave blank to deploy): '
     );
   }
+}
 
-  if (!config.targetVerifierAddress) {
-    console.error('No address provided for the target verifier but one is required.');
-    process.exit();
+async function getTypeOfVerifierToDeploy(config) {
+  console.log('Asking for verifier type');
+
+  if (!config.typeOfVerifierToDeploy) {
+    config.typeOfVerifierToDeploy = process.env.TYPE_OF_VERIFIER_TO_DEPLOY;
+  }
+
+  if (!config.typeOfVerifierToDeploy) {
+    config.typeOfVerifierToDeploy = await ask(
+      'Enter the type of verifier to deploy ["insert" | "update"]: '
+    );
+
+    if (config.typeOfVerifierToDeploy !== "insert"
+    && config.typeOfVerifierToDeploy !== "update") {
+      console.error('Invalid verifier type provided.');
+      process.exit(1);
+    }
   }
 }
 
@@ -1448,7 +1492,6 @@ async function buildIdentityManagerDeploymentActionPlan(plan, config) {
     );
   }
   await deployIdentityManager(plan, config, insertLUTTargetField, updateLUTTargetField);
-  config.routerInitialRoute = config.identityManagerContractAddress;
   await deployRouter(plan, config);
 }
 
@@ -1585,11 +1628,33 @@ async function buildVerifierActionPlan(plan, config, type) {
   await getRpcUrl(config);
   await getProvider(config);
   await getWallet(config);
-  await getLookupTableAddress(config);
-  await getBatchSize(config);
+
   if (type !== 'disable') {
     await getTargetVerifierAddress(config);
   }
+
+  const isAddOrUpdate = (type === "add") || (type === "update");
+  const shouldDeploy = config.targetVerifierAddress === undefined || config.targetVerifierAddress === "";
+
+  if (isAddOrUpdate && shouldDeploy) {
+    await getTypeOfVerifierToDeploy(config);
+  }
+
+  await getIdentityManagerContractAddress(config);
+  await getLookupTableAddress(config);
+  await getBatchSize(config);
+
+  if (isAddOrUpdate && shouldDeploy) {
+    if (config.typeOfVerifierToDeploy === "insert") {
+      await ensureVerifierDeployment(plan, config);
+    } else if (config.typeOfVerifierToDeploy === "update") {
+      await ensureUnimplementedTreeVerifierDeployment(plan, config);
+    } else {
+      console.error(`INTERNAL ERROR: Unrecognised type of verifier to deploy: ${config.typeOfVerifierToDeploy}`);
+      process.exit(0);
+    }
+  }
+
 
   if (type === 'add') {
     await addVerifierToLUT(plan, config);


### PR DESCRIPTION
Makes it so that:
1. `verifier-add` asks for the identity manager contract address if it's needed (it's needed to figure out the LUT address)
2. Deploys the new verifier (either insert or update type) if address is not provided