### PR TITLE
Introduce more fine-grained permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,11 @@ deploy: install build; node --no-warnings scripts/deploy.js deploy
 # Upgrade contracts
 upgrade: install build; node --no-warnings scripts/deploy.js upgrade
 
-# Deploy contracts
+# Transfer contract ownership
 transfer-ownership: install build; node --no-warnings scripts/deploy.js transfer
+
+# Set the identity manager's identity operator
+set-operator: install build; node --no-warnings scripts/deploy.js set-operator
 
 # ===== Verifier Management Rules =====================================================================================
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<center><img src="https://github.com/worldcoin/world-id-docs/raw/main/public/images/shared-readme/readme-world-id.png" alt="World ID Logo"/></center>
+
 # WorldID Semaphore Contracts
 
 > These are the underlying contracts that power World ID. If you're looking to integrate with World
@@ -5,9 +7,11 @@
 > [Hardhat](https://github.com/worldcoin/world-id-starter-hardhat) starter kits.
 
 This repository contains the underlying contracts that make World ID work, powered by the
-[Semaphore library](http://semaphore.appliedzkp.org/).
+[Semaphore library](http://semaphore.appliedzkp.org/). These contracts are responsible for
+performing identity operations on chain, and attestation of identities for the purposes of semaphore
+proofs.
 
-## <img align="left" width="28" height="28" src="https://github.com/worldcoin/world-id-docs/raw/main/public/icons/logo.svg" alt="" style="margin-right: 0;" /> About World ID
+## <img align="left" width="28" height="28" src="https://raw.githubusercontent.com/worldcoin/world-id-docs/main/public/images/shared-readme/readme-world-id.png" alt="World ID Logo" style="margin-right: 5;" /> About World ID
 
 World ID is a protocol that lets you **prove a human is doing an action only once without revealing
 any personal data**. Stop bots, stop abuse.
@@ -21,15 +25,55 @@ ever public.
 World ID is meant for on-chain web3 apps, traditional Cloud applications, and even IRL
 verifications. Go to the [World ID app](https://worldcoin.org/download-app) to get started.
 
-<img src="https://github.com/worldcoin/world-id-docs/raw/main/public/images/docs/introduction/how-it-works-light.svg" alt="Diagram of how World ID works."  />
+<img src="https://github.com/worldcoin/world-id-docs/raw/main/public/images/docs/introduction/worldcoin-sign-in.jpg" alt="Worldcoin Sign In"  />
 
-## Deployment
+## Privileged Actions and Trust
 
-Deploying the Semaphore contract will require generating a verifier contract for our batch insertion
-service. Calling `make deploy` will guide you through the process of downloading the relevant tools,
-initializing and creating the required contracts.
+The WorldID Identity Manager uses a bifircated notion of privelege in production. This operates as
+follows:
 
-## Testing
+- **Owner:** The owner is responsible for administrating the contract. In production, the contract's
+  owner will be a multi-signature wallet.
+- **Identity Operator:** The identity operator is responsible for performing identity operations
+  using the contract. In production, the contract's identity operator will be a wallet associated
+  with [OpenZeppelin Relay](https://docs.openzeppelin.com/defender/relay), ensuring that identities
+  are submitted on-chain reliably and in order.
+
+All other contracts use a simple notion of an "owner", that will be held by a multi-signature wallet
+in production.
+
+What follows below is a table of privileged operations in the WorldID Identity Manager contract, and
+which of the _owner_ and _identity operator_ has the permission to perform these actions.
+
+| Operation                                  | Privileges        | Description                                                                                                                           |
+| :----------------------------------------- | :---------------- | :------------------------------------------------------------------------------------------------------------------------------------ |
+| `acceptOwnership`                          | New Owner         | Accepts the transfer of ownership.                                                                                                    |
+| `disableStateBridge`                       | Owner             | Turns off the state bridge.                                                                                                           |
+| `enableStateBridge`                        | Owner             | Turns on the state bridge.                                                                                                            |
+| `registerIdentities`                       | Identity Operator | Registers new identity commitments into the World ID system.                                                                          |
+| `setIdentitiUpdateVerifierLookupTable`     | Owner             | Sets the table of verifiers used to verify proofs that correspond to identity updates.                                                |
+| `setIdentityOperator`                      | Owner             | Sets the address that has permission to act as the Identity Operator.                                                                 |
+| `setRegisterIdentitiesVerifierLookupTable` | Owner             | Sets the table of verifiers used to verify proofs that correspond to identity insertions.                                             |
+| `setRootHistoryExpiry`                     | Owner             | Sets the amount of time it takes for a non-current tree root to expire.                                                               |
+| `setSemaphoreVerifier`                     | Owner             | Sets the contract used to verify semaphore proofs.                                                                                    |
+| `setStateBridge`                           | Owner             | Sets the address of the state bridge. The state bridge is the contract responsible for sending identity tree updates to other chains. |
+| `transferOwnership`                        | Owner             | Transfers ownership from the current owner to a new owner using a two-step process.                                                   |
+| `updateIdentities`                         | Identity Operator | Updates existing identity commitments in the World ID system. Updates are able to remove identities as well.                          |
+| `upgradeTo`                                | Owner             | Upgrades the implementation of the identiy manager to a new version.                                                                  |
+| `upgradeToAndCall`                         | Owner             | Upgrades the implementation of the identity manager to a new version and executes a function call while doing so.                     |
+
+## Development
+
+This repository uses the [Foundry](https://github.com/gakonst/foundry) smart contract toolkit. You
+can download the Foundry installer by running `curl -L https://foundry.paradigm.xyz | bash`, and
+then install the latest version by running `foundryup` on a new terminal window (additional
+instructions are available [on the Foundry repo](https://github.com/gakonst/foundry#installation)).
+You'll also need [Node.js](https://nodejs.org) if you're planning to run the automated tests.
+
+Once you have everything installed, you can run `make` from the base directory to install all
+dependencies and build the smart contracts.
+
+### Testing
 
 The prover service comes with a way to generate test parameters—a mock insertion of a batch of
 consecutive commitments into the tree. Assuming you've already run `make deploy`, the prover serivce
@@ -50,18 +94,8 @@ The output of this, together with the relevant parts of the generated test param
 a correct input to the `registerIdentities` method of the `Semaphore` contract, as long as it was
 deployed using the same keys file.
 
-## Usage with Worldcoin
+### Deployment
 
-See [the starter kit](https://github.com/worldcoin/world-id-starter#-usage-instructions) for
-detailed instructions on how to integrate with World ID.
-
-## Development
-
-This repository uses the [Foundry](https://github.com/gakonst/foundry) smart contract toolkit. You
-can download the Foundry installer by running `curl -L https://foundry.paradigm.xyz | bash`, and
-then install the latest version by running `foundryup` on a new terminal window (additional
-instructions are available [on the Foundry repo](https://github.com/gakonst/foundry#installation)).
-You'll also need [Node.js](https://nodejs.org) if you're planning to run the automated tests.
-
-Once you have everything installed, you can run `make` from the base directory to install all
-dependencies and build the smart contracts.
+Deploying the Semaphore contract will require generating a verifier contract for our batch insertion
+service. Calling `make deploy` will guide you through the process of downloading the relevant tools,
+initializing and creating the required contracts.

--- a/src/WorldIDIdentityManagerImplV1.sol
+++ b/src/WorldIDIdentityManagerImplV1.sol
@@ -306,7 +306,7 @@ contract WorldIDIdentityManagerImplV1 is WorldIDImpl, IWorldID {
         uint32 startIndex,
         uint256[] calldata identityCommitments,
         uint256 postRoot
-    ) public virtual onlyProxy onlyInitialized onlyOwner {
+    ) public virtual onlyProxy onlyInitialized onlyIdentityOperator {
         // We can only operate on the latest root in reduced form.
         if (!isInputInReducedForm(preRoot)) {
             revert UnreducedElement(UnreducedElementType.PreRoot, preRoot);
@@ -417,7 +417,7 @@ contract WorldIDIdentityManagerImplV1 is WorldIDImpl, IWorldID {
         uint256[] calldata oldIdentities,
         uint256[] calldata newIdentities,
         uint256 postRoot
-    ) public virtual onlyProxy onlyInitialized onlyOwner {
+    ) public virtual onlyProxy onlyInitialized onlyIdentityOperator {
         // We can only operate on the latest root in reduced form.
         if (!isInputInReducedForm(preRoot)) {
             revert UnreducedElement(UnreducedElementType.PreRoot, preRoot);
@@ -487,7 +487,7 @@ contract WorldIDIdentityManagerImplV1 is WorldIDImpl, IWorldID {
         uint256 inputHash,
         uint256 preRoot,
         uint256 postRoot
-    ) internal virtual onlyProxy onlyInitialized onlyOwner {
+    ) internal virtual onlyProxy onlyInitialized onlyIdentityOperator {
         // Pull out the proof terms and verifier input.
         uint256[2] memory ar = [updateProof[0], updateProof[1]];
         uint256[2][2] memory bs =

--- a/src/test/identity-manager/WorldIDIdentityManagerIdentityRegistration.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerIdentityRegistration.t.sol
@@ -64,12 +64,14 @@ contract WorldIDIdentityManagerIdentityRegistration is WorldIDIdentityManagerTes
         uint32 newStartIndex,
         uint128 newPreRoot,
         uint128 newPostRoot,
-        uint128[] memory identities
+        uint128[] memory identities,
+        address identityOperator
     ) public {
         // Setup
         vm.assume(SimpleVerify.isValidInput(uint256(prf[0])));
         vm.assume(newPreRoot != newPostRoot);
         vm.assume(identities.length <= 1000);
+        vm.assume(identityOperator != nullAddress && identityOperator != thisAddress);
         (VerifierLookupTable insertVerifiers, VerifierLookupTable updateVerifiers) =
             makeVerifierLookupTables(TC.makeDynArray([identities.length]));
         makeNewIdentityManager(
@@ -88,9 +90,15 @@ contract WorldIDIdentityManagerIdentityRegistration is WorldIDIdentityManagerTes
             (actualProof, newPreRoot, newStartIndex, preparedIdents, newPostRoot)
         );
 
+        bytes memory setupCallData =
+            abi.encodeCall(ManagerImpl.setIdentityOperator, identityOperator);
+        (bool success,) = identityManagerAddress.call(setupCallData);
+        assert(success);
+
         // Expect the root to have been sent to the state bridge.
         vm.expectEmit(true, true, true, true);
         emit StateRootSentMultichain(newPostRoot);
+        vm.prank(identityOperator);
 
         // Test
         assertCallSucceedsOn(identityManagerAddress, callData);

--- a/src/test/identity-manager/WorldIDIdentityManagerIdentityRegistration.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerIdentityRegistration.t.sol
@@ -319,16 +319,18 @@ contract WorldIDIdentityManagerIdentityRegistration is WorldIDIdentityManagerTes
         assertCallFailsOn(identityManagerAddress, registerCallData, expectedError);
     }
 
-    /// @notice Tests that it reverts if an attempt is made to register identities as a non-manager.
-    function testCannotRegisterIdentitiesAsNonManager(address nonManager) public {
+    /// @notice Tests that it reverts if an attempt is made to register identities as an address
+    ///         that is not the identity operator address.
+    function testCannotRegisterIdentitiesAsNonIdentityOperator(address nonOperator) public {
         // Setup
-        vm.assume(nonManager != address(this) && nonManager != address(0x0));
+        vm.assume(nonOperator != address(this) && nonOperator != address(0x0));
         bytes memory callData = abi.encodeCall(
             ManagerImpl.registerIdentities,
             (proof, preRoot, startIndex, identityCommitments, postRoot)
         );
-        bytes memory errorData = encodeStringRevert("Ownable: caller is not the owner");
-        vm.prank(nonManager);
+        bytes memory errorData =
+            abi.encodeWithSelector(ManagerImpl.Unauthorized.selector, nonOperator);
+        vm.prank(nonOperator);
 
         // Test
         assertCallFailsOn(identityManagerAddress, callData, errorData);

--- a/src/test/identity-manager/WorldIDIdentityManagerIdentityUpdate.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerIdentityUpdate.t.sol
@@ -247,14 +247,15 @@ contract WorldIDIdentityManagerIdentityUpdate is WorldIDIdentityManagerTest {
         assertCallFailsOn(identityManagerAddress, callData, expectedError);
     }
 
-    /// @notice Tests that it reverts if an attempt is made to update identities as a non-manager.
-    function testCannotUpdateIdentitiesAsNonManager(
-        address nonManager,
+    /// @notice Tests that it reverts if an attempt is made to update identities as an address that
+    ///         is not the identity operator address.
+    function testCannotUpdateIdentitiesAsNonIdentityOperator(
+        address nonOperator,
         uint128[] memory identities,
         uint128[8] memory prf
     ) public {
         // Setup
-        vm.assume(nonManager != address(this) && nonManager != address(0x0));
+        vm.assume(nonOperator != address(this) && nonOperator != address(0x0));
         (
             uint32[] memory leafIndices,
             uint256[] memory oldIdents,
@@ -265,8 +266,9 @@ contract WorldIDIdentityManagerIdentityUpdate is WorldIDIdentityManagerTest {
             ManagerImpl.updateIdentities,
             (actualProof, preRoot, leafIndices, oldIdents, newIdents, postRoot)
         );
-        bytes memory errorData = encodeStringRevert("Ownable: caller is not the owner");
-        vm.prank(nonManager);
+        bytes memory errorData =
+            abi.encodeWithSelector(ManagerImpl.Unauthorized.selector, nonOperator);
+        vm.prank(nonOperator);
 
         // Test
         assertCallFailsOn(identityManagerAddress, callData, errorData);

--- a/src/test/identity-manager/WorldIDIdentityManagerOwnershipManagement.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerOwnershipManagement.t.sol
@@ -86,4 +86,39 @@ contract WorldIDIdentityManagerOwnershipManagement is WorldIDIdentityManagerTest
         // Test
         assertCallFailsOn(identityManagerAddress, callData, returnData);
     }
+
+    /// @notice Enures that the contract has a notion of identity operator.
+    function testHasIdentityOperator() public {
+        // Setup
+        bytes memory callData = abi.encodeCall(ManagerImpl.identityOperator, ());
+        bytes memory returnData = abi.encode(thisAddress);
+
+        // Test
+        assertCallSucceedsOn(identityManagerAddress, callData, returnData);
+    }
+
+    /// @notice Ensures that it is possible for the owner to set the address of the identity
+    ///         operator.
+    function testCanSetIdentityOperatorAsOwner(address newOperator) public {
+        // Setup
+        vm.assume(newOperator != thisAddress);
+        bytes memory callData = abi.encodeCall(ManagerImpl.setIdentityOperator, (newOperator));
+        bytes memory returnData = abi.encode(thisAddress);
+
+        // Test
+        assertCallSucceedsOn(identityManagerAddress, callData, returnData);
+    }
+
+    /// @notice Ensures that it is not possible for a non-owner to set the address of the identity
+    ///         operator
+    function testCannotSetIdentityOperatorAsNonOwner(address newOperator, address naughty) public {
+        // Setup
+        vm.assume(naughty != nullAddress && naughty != thisAddress);
+        bytes memory callData = abi.encodeCall(ManagerImpl.setIdentityOperator, (newOperator));
+        bytes memory errorData = encodeStringRevert("Ownable: caller is not the owner");
+        vm.prank(naughty);
+
+        // Test
+        assertCallFailsOn(identityManagerAddress, callData, errorData);
+    }
 }

--- a/src/test/identity-manager/WorldIDIdentityManagerUninit.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerUninit.t.sol
@@ -238,4 +238,30 @@ contract WorldIDIdentityManagerUninit is WorldIDIdentityManagerTest {
         // Test
         assertCallFailsOn(identityManagerAddress, callData, expectedError);
     }
+
+    /// @notice Checks that it is impossible to call `identityOperator` while the contract is not
+    ///         initialized.
+    function testShouldNotCallIdentityOperatorWhileUninit() public {
+        // Setup
+        makeUninitIdentityManager();
+        bytes memory callData = abi.encodeCall(ManagerImpl.identityOperator, ());
+        bytes memory expectedError =
+            abi.encodeWithSelector(CheckInitialized.ImplementationNotInitialized.selector);
+
+        // Test
+        assertCallFailsOn(identityManagerAddress, callData, expectedError);
+    }
+
+    /// @notice Checks that it is impossible to call `setIdentityOperator` while the contract is not
+    ///         initialized.
+    function testShouldNotCallSetIdentityOperatorWhileUninit(address newOperator) public {
+        // Setup
+        makeUninitIdentityManager();
+        bytes memory callData = abi.encodeCall(ManagerImpl.setIdentityOperator, (newOperator));
+        bytes memory expectedError =
+            abi.encodeWithSelector(CheckInitialized.ImplementationNotInitialized.selector);
+
+        // Test
+        assertCallFailsOn(identityManagerAddress, callData, expectedError);
+    }
 }


### PR DESCRIPTION
This PR updates the identity manager to use a split permissions model for the role that administrates the contract and the role with permission to perform identity operations. This both makes things less centralised and greatly simplifies deployment with OZ relay (hence making it much more tractable to use a two-step ownership mechanism).