### PR TITLE
chore: Preserve the existing `IWorldID` interface

### DIFF
--- a/src/WorldIDRouterImplV1.sol
+++ b/src/WorldIDRouterImplV1.sol
@@ -329,8 +329,8 @@ contract WorldIDRouterImplV1 is WorldIDImpl, IWorldIDGroups {
     /// @dev Note that a double-signaling check is not included here, and should be carried by the
     ///      caller.
     ///
-    /// @param groupId The group identifier for the group to verify a proof for.
     /// @param root The of the Merkle tree
+    /// @param groupId The group identifier for the group to verify a proof for.
     /// @param signalHash A keccak256 hash of the Semaphore signal
     /// @param nullifierHash The nullifier hash
     /// @param externalNullifierHash A keccak256 hash of the external nullifier
@@ -340,8 +340,8 @@ contract WorldIDRouterImplV1 is WorldIDImpl, IWorldIDGroups {
     ///                 `IWorldID` implementation being called into.
     /// @custom:reverts NoSuchGroup If the provided `groupId` references a group that does not exist.
     function verifyProof(
-        uint256 groupId,
         uint256 root,
+        uint256 groupId,
         uint256 signalHash,
         uint256 nullifierHash,
         uint256 externalNullifierHash,

--- a/src/interfaces/IWorldIDGroups.sol
+++ b/src/interfaces/IWorldIDGroups.sol
@@ -20,8 +20,8 @@ interface IWorldIDGroups {
     /// @custom:reverts string If the `proof` is invalid.
     /// @custom:reverts NoSuchGroup If the provided `groupId` references a group that does not exist.
     function verifyProof(
-        uint256 groupId,
         uint256 root,
+        uint256 groupId,
         uint256 signalHash,
         uint256 nullifierHash,
         uint256 externalNullifierHash,

--- a/src/test/identity-manager/WorldIDIdentityManagerIdentityRegistration.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerIdentityRegistration.t.sol
@@ -155,13 +155,15 @@ contract WorldIDIdentityManagerIdentityRegistration is WorldIDIdentityManagerTes
         emit VerifiedProof(identities.length);
         vm.expectEmit(true, true, true, true);
         emit StateRootSentMultichain(newPostRoot);
+
+        // Test
+        assertCallSucceedsOn(identityManagerAddress, firstCallData);
+
         vm.expectEmit(true, true, true, true);
         emit VerifiedProof(identities.length / 2);
         vm.expectEmit(true, true, true, true);
         emit StateRootSentMultichain(secondPostRoot);
 
-        // Test
-        assertCallSucceedsOn(identityManagerAddress, firstCallData);
         assertCallSucceedsOn(identityManagerAddress, secondCallData);
     }
 

--- a/src/test/identity-manager/WorldIDIdentityManagerIdentityUpdate.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerIdentityUpdate.t.sol
@@ -176,13 +176,15 @@ contract WorldIDIdentityManagerIdentityUpdate is WorldIDIdentityManagerTest {
         emit VerifiedProof(oldIdents.length);
         vm.expectEmit(true, true, true, true);
         emit StateRootSentMultichain(newPostRoot);
+
+        // Test
+        assertCallSucceedsOn(identityManagerAddress, firstCallData);
+
         vm.expectEmit(true, true, true, true);
         emit VerifiedProof(secondOldIdents.length);
         vm.expectEmit(true, true, true, true);
         emit StateRootSentMultichain(secondPostRoot);
 
-        // Test
-        assertCallSucceedsOn(identityManagerAddress, firstCallData);
         assertCallSucceedsOn(identityManagerAddress, secondCallData);
     }
 

--- a/src/test/identity-manager/WorldIDIdentityManagerOwnershipManagement.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerOwnershipManagement.t.sol
@@ -51,13 +51,14 @@ contract WorldIDIdentityManagerOwnershipManagement is WorldIDIdentityManagerTest
         bytes memory pendingOwnerCallData = abi.encodeCall(Ownable2StepUpgradeable.pendingOwner, ());
         bytes memory acceptOwnerCallData =
             abi.encodeCall(Ownable2StepUpgradeable.acceptOwnership, ());
-        vm.expectEmit(true, true, true, true);
-        emit OwnershipTransferred(thisAddress, newOwner);
 
         // Test
         assertCallSucceedsOn(identityManagerAddress, transferCallData, new bytes(0x0));
         assertCallSucceedsOn(identityManagerAddress, pendingOwnerCallData, abi.encode(newOwner));
         assertCallSucceedsOn(identityManagerAddress, ownerCallData, abi.encode(thisAddress));
+
+        vm.expectEmit(true, true, true, true);
+        emit OwnershipTransferred(thisAddress, newOwner);
 
         vm.prank(newOwner);
         assertCallSucceedsOn(identityManagerAddress, acceptOwnerCallData, new bytes(0x0));

--- a/src/test/identity-manager/WorldIDIdentityManagerStateBridge.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerStateBridge.t.sol
@@ -62,8 +62,6 @@ contract WorldIDIdentityManagerStateBridge is WorldIDIdentityManagerTest {
         // expect event that state root was sent to state bridge
         vm.expectEmit(true, true, true, true);
         emit StateRootSentMultichain(postRoot);
-        vm.expectEmit(true, true, true, true);
-        emit StateBridgeStateChange(false);
 
         // Test
         assertCallSucceedsOn(identityManagerAddress, registerCallData);
@@ -73,6 +71,10 @@ contract WorldIDIdentityManagerStateBridge is WorldIDIdentityManagerTest {
             queryRootCallData,
             abi.encode(ManagerImpl.RootInfo(postRoot, 0, true))
         );
+
+        vm.expectEmit(true, true, true, true);
+        emit StateBridgeStateChange(false);
+
         assertCallSucceedsOn(identityManagerAddress, callData, new bytes(0x0));
     }
 

--- a/src/test/router/WorldIDRouterOwnershipManagement.t.sol
+++ b/src/test/router/WorldIDRouterOwnershipManagement.t.sol
@@ -42,13 +42,14 @@ contract WorldIDRouterOwnershipManagement is WorldIDRouterTest {
         bytes memory pendingOwnerCallData = abi.encodeCall(Ownable2StepUpgradeable.pendingOwner, ());
         bytes memory acceptOwnerCallData =
             abi.encodeCall(Ownable2StepUpgradeable.acceptOwnership, ());
-        vm.expectEmit(true, true, true, true);
-        emit OwnershipTransferred(thisAddress, newOwner);
 
         // Test
         assertCallSucceedsOn(routerAddress, transferCallData, new bytes(0x0));
         assertCallSucceedsOn(routerAddress, pendingOwnerCallData, abi.encode(newOwner));
         assertCallSucceedsOn(routerAddress, ownerCallData, abi.encode(thisAddress));
+
+        vm.expectEmit(true, true, true, true);
+        emit OwnershipTransferred(thisAddress, newOwner);
 
         vm.prank(newOwner);
         assertCallSucceedsOn(routerAddress, acceptOwnerCallData, new bytes(0x0));

--- a/src/test/router/WorldIDRouterStateBridge.t.sol
+++ b/src/test/router/WorldIDRouterStateBridge.t.sol
@@ -84,7 +84,7 @@ contract WorldIDRouterStateBridge is WorldIDRouterTest {
 
         bytes memory callData = abi.encodeCall(
             RouterImpl.verifyProof,
-            (uint256(groupId), root, signalHash, nullifierHash, externalNullifierHash, proof)
+            (root, uint256(groupId), signalHash, nullifierHash, externalNullifierHash, proof)
         );
 
         bool shouldSucceed = proof[0] % 2 == 0;

--- a/src/test/verifier-lookup-table/VerifierLookupTableOwnershipManagement.t.sol
+++ b/src/test/verifier-lookup-table/VerifierLookupTableOwnershipManagement.t.sol
@@ -27,12 +27,13 @@ contract VerifierLookupTableOwnershipManagement is VerifierLookupTableTest {
     function testTransferOwner(address newOwner) public {
         // Setup
         vm.assume(newOwner != nullAddress);
-        vm.expectEmit(true, true, true, true);
-        emit OwnershipTransferred(thisAddress, newOwner);
 
         // Test 1
         lookupTable.transferOwnership(newOwner);
         assertEq(lookupTable.pendingOwner(), newOwner);
+
+        vm.expectEmit(true, true, true, true);
+        emit OwnershipTransferred(thisAddress, newOwner);
 
         // Test 2
         vm.prank(newOwner);


### PR DESCRIPTION
Noticed the interface for the `verifyProof` function is very close to the one that we were using before, except for the order of the first two parameters.

By preserving the interface, existing contracts that include a methods to upgrade the Semaphore contract address can easily switch to the new version without having to redeploy their contracts. It should also make the change less confusing for people who have used World ID in the past.