### PR TITLE
chore: restrict verify proof interface to view

### DIFF
--- a/src/interfaces/IWorldID.sol
+++ b/src/interfaces/IWorldID.sol
@@ -25,5 +25,5 @@ interface IWorldID is IBaseWorldID {
         uint256 nullifierHash,
         uint256 externalNullifierHash,
         uint256[8] calldata proof
-    ) external;
+    ) external view;
 }

--- a/src/test/mock/SimpleStateBridge.sol
+++ b/src/test/mock/SimpleStateBridge.sol
@@ -20,16 +20,13 @@ contract SimpleStateBridge is IBridge, IWorldID {
         emit SetRootHistoryExpiry(expiryTime);
     }
 
-    event ProofVerified(uint256 indexed root);
-
     error ProofNotVerified();
 
-    function verifyProof(uint256 root, uint256, uint256, uint256, uint256[8] calldata proof)
+    function verifyProof(uint256, uint256, uint256, uint256, uint256[8] calldata proof)
         external
+        pure
     {
-        if (proof[0] % 2 == 0) {
-            emit ProofVerified(root);
-        } else {
+        if (proof[0] % 2 != 0) {
             revert ProofNotVerified();
         }
     }

--- a/src/test/router/WorldIDRouterStateBridge.t.sol
+++ b/src/test/router/WorldIDRouterStateBridge.t.sol
@@ -90,10 +90,7 @@ contract WorldIDRouterStateBridge is WorldIDRouterTest {
         bool shouldSucceed = proof[0] % 2 == 0;
 
         bytes memory errorData = new bytes(0);
-        if (shouldSucceed) {
-            vm.expectEmit(true, true, true, true);
-            emit ProofVerified(root);
-        } else {
+        if (!shouldSucceed) {
             errorData = abi.encodeWithSelector(SimpleStateBridge.ProofNotVerified.selector);
         }
 


### PR DESCRIPTION
Restricts the `IWorldID` `verifyProof` interface definition to `view` as to match the implementation in the `WorldIDIdentityManagerImplV1` [here](https://github.com/worldcoin/world-id-contracts/blob/5835348737a699c3704a12adb298ce10c9e513f5/src/WorldIDIdentityManagerImplV1.sol#L677).

This is useful when verifying a proof from a view only function in another contract without having to create a new interface. 