### PR TITLE
Use a real Semaphore Verifier for the inclusion proof tests instead of mocks.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,8 +1,8 @@
 # === Default Profile =========================================================
 
 [profile.default]
-solc = "0.8.21"
-evm_version = "paris"
+solc = "0.8.29"
+evm_version = "shanghai"
 src = 'src'
 out = 'out'
 libs = ['lib']
@@ -14,7 +14,7 @@ remappings = [
   '@zk-kit/=lib/zk-kit/packages/',
   'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/',
   'contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/',
-  'semaphore/=lib/semaphore/packages/contracts/contracts/'
+  'semaphore/=lib/semaphore/packages/contracts/contracts/',
 ]
 
 # The default is to optimise, but let's be clear about it.
@@ -22,10 +22,10 @@ optimizer = true
 
 # Make formatting consistent.
 [profile.default.fmt]
-line_length = 100               # The maximum length of lines.
-tab_width = 4                   # Indent by two spaces for each level.
-bracket_spacing = false         # Don't put spaces between brackets and content.
-int_types = "long"              # Specify full integer type names.
+line_length = 100       # The maximum length of lines.
+tab_width = 4           # Indent by two spaces for each level.
+bracket_spacing = false # Don't put spaces between brackets and content.
+int_types = "long"      # Specify full integer type names.
 
 # We want to optimise via the new optimiser backend for better results.
 via_ir = true
@@ -42,7 +42,7 @@ constant_optimizer = true # Computes some constant expressions at compile time.
 yul = true                # Enables the new ABI optimiser.
 
 [profile.default.optimizer_details.yul_details]
-stack_allocation = true   # Improves allocation of stack slots for variables.
+stack_allocation = true # Improves allocation of stack slots for variables.
 
 # === Debug Profile ===========================================================
 
@@ -71,7 +71,7 @@ gas_reports = [
   "Verifier",
   "WorldIDRouter",
   "WorldIDRouterImplV1",
-  "VerifierLookupTable"
+  "VerifierLookupTable",
 ]
 
 # === Production Profile ======================================================

--- a/src/data/VerifierLookupTable.sol
+++ b/src/data/VerifierLookupTable.sol
@@ -48,7 +48,10 @@ contract VerifierLookupTable is Ownable2Step {
     ///
     /// @param batchSize The size of the batch that the verifier has been added for.
     /// @param verifierAddress The address of the verifier that was associated with `batchSize`.
-    event VerifierAdded(uint256 indexed batchSize, address indexed verifierAddress);
+    event VerifierAdded(
+        uint256 indexed batchSize,
+        address indexed verifierAddress
+    );
 
     /// @notice Emitted when a verifier is updated in the lookup table.
     ///
@@ -85,7 +88,9 @@ contract VerifierLookupTable is Ownable2Step {
     /// @return verifier The tree verifier for the provided `batchSize`.
     ///
     /// @custom:reverts NoSuchVerifier If there is no verifier associated with the `batchSize`.
-    function getVerifierFor(uint256 batchSize) public view returns (ITreeVerifier verifier) {
+    function getVerifierFor(
+        uint256 batchSize
+    ) public view returns (ITreeVerifier verifier) {
         // Check the preconditions for querying the verifier.
         validateVerifier(batchSize);
 
@@ -100,7 +105,10 @@ contract VerifierLookupTable is Ownable2Step {
     ///
     /// @custom:reverts VerifierExists If `batchSize` already has an associated verifier.
     /// @custom:reverts string If the caller is not the owner.
-    function addVerifier(uint256 batchSize, ITreeVerifier verifier) public onlyOwner {
+    function addVerifier(
+        uint256 batchSize,
+        ITreeVerifier verifier
+    ) public onlyOwner {
         // Check that there is no entry for that batch size.
         if (verifier_lut[batchSize] != nullVerifier) {
             revert VerifierExists();
@@ -119,14 +127,17 @@ contract VerifierLookupTable is Ownable2Step {
     /// @return oldVerifier The old verifier instance associated with this batch size.
     ///
     /// @custom:reverts string If the caller is not the owner.
-    function updateVerifier(uint256 batchSize, ITreeVerifier verifier)
-        public
-        onlyOwner
-        returns (ITreeVerifier oldVerifier)
-    {
+    function updateVerifier(
+        uint256 batchSize,
+        ITreeVerifier verifier
+    ) public onlyOwner returns (ITreeVerifier oldVerifier) {
         oldVerifier = verifier_lut[batchSize];
         verifier_lut[batchSize] = verifier;
-        emit VerifierUpdated(batchSize, address(oldVerifier), address(verifier));
+        emit VerifierUpdated(
+            batchSize,
+            address(oldVerifier),
+            address(verifier)
+        );
     }
 
     /// @notice Disables the verifier for the provided batch size.
@@ -136,11 +147,9 @@ contract VerifierLookupTable is Ownable2Step {
     /// @return oldVerifier The old verifier associated with the batch size.
     ///
     /// @custom:reverts string If the caller is not the owner.
-    function disableVerifier(uint256 batchSize)
-        public
-        onlyOwner
-        returns (ITreeVerifier oldVerifier)
-    {
+    function disableVerifier(
+        uint256 batchSize
+    ) public onlyOwner returns (ITreeVerifier oldVerifier) {
         oldVerifier = updateVerifier(batchSize, ITreeVerifier(nullAddress));
         emit VerifierDisabled(batchSize);
     }

--- a/src/data/VerifierLookupTable.sol
+++ b/src/data/VerifierLookupTable.sol
@@ -48,10 +48,7 @@ contract VerifierLookupTable is Ownable2Step {
     ///
     /// @param batchSize The size of the batch that the verifier has been added for.
     /// @param verifierAddress The address of the verifier that was associated with `batchSize`.
-    event VerifierAdded(
-        uint256 indexed batchSize,
-        address indexed verifierAddress
-    );
+    event VerifierAdded(uint256 indexed batchSize, address indexed verifierAddress);
 
     /// @notice Emitted when a verifier is updated in the lookup table.
     ///
@@ -88,9 +85,7 @@ contract VerifierLookupTable is Ownable2Step {
     /// @return verifier The tree verifier for the provided `batchSize`.
     ///
     /// @custom:reverts NoSuchVerifier If there is no verifier associated with the `batchSize`.
-    function getVerifierFor(
-        uint256 batchSize
-    ) public view returns (ITreeVerifier verifier) {
+    function getVerifierFor(uint256 batchSize) public view returns (ITreeVerifier verifier) {
         // Check the preconditions for querying the verifier.
         validateVerifier(batchSize);
 
@@ -105,10 +100,7 @@ contract VerifierLookupTable is Ownable2Step {
     ///
     /// @custom:reverts VerifierExists If `batchSize` already has an associated verifier.
     /// @custom:reverts string If the caller is not the owner.
-    function addVerifier(
-        uint256 batchSize,
-        ITreeVerifier verifier
-    ) public onlyOwner {
+    function addVerifier(uint256 batchSize, ITreeVerifier verifier) public onlyOwner {
         // Check that there is no entry for that batch size.
         if (verifier_lut[batchSize] != nullVerifier) {
             revert VerifierExists();
@@ -127,17 +119,14 @@ contract VerifierLookupTable is Ownable2Step {
     /// @return oldVerifier The old verifier instance associated with this batch size.
     ///
     /// @custom:reverts string If the caller is not the owner.
-    function updateVerifier(
-        uint256 batchSize,
-        ITreeVerifier verifier
-    ) public onlyOwner returns (ITreeVerifier oldVerifier) {
+    function updateVerifier(uint256 batchSize, ITreeVerifier verifier)
+        public
+        onlyOwner
+        returns (ITreeVerifier oldVerifier)
+    {
         oldVerifier = verifier_lut[batchSize];
         verifier_lut[batchSize] = verifier;
-        emit VerifierUpdated(
-            batchSize,
-            address(oldVerifier),
-            address(verifier)
-        );
+        emit VerifierUpdated(batchSize, address(oldVerifier), address(verifier));
     }
 
     /// @notice Disables the verifier for the provided batch size.
@@ -147,9 +136,11 @@ contract VerifierLookupTable is Ownable2Step {
     /// @return oldVerifier The old verifier associated with the batch size.
     ///
     /// @custom:reverts string If the caller is not the owner.
-    function disableVerifier(
-        uint256 batchSize
-    ) public onlyOwner returns (ITreeVerifier oldVerifier) {
+    function disableVerifier(uint256 batchSize)
+        public
+        onlyOwner
+        returns (ITreeVerifier oldVerifier)
+    {
         oldVerifier = updateVerifier(batchSize, ITreeVerifier(nullAddress));
         emit VerifierDisabled(batchSize);
     }

--- a/src/test/SemaphoreVerifier16.sol
+++ b/src/test/SemaphoreVerifier16.sol
@@ -36,8 +36,10 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     //     t = 4965661367192848881
     //     P = 36⋅t⁴ + 36⋅t³ + 24⋅t² + 6⋅t + 1
     //     R = 36⋅t⁴ + 36⋅t³ + 18⋅t² + 6⋅t + 1
-    uint256 constant P = 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47;
-    uint256 constant R = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+    uint256 constant P =
+        0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47;
+    uint256 constant R =
+        0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
 
     // Extension field Fp2 = Fp[i] / (i² + 1)
     // Note: This is the complex extension field of Fp with i² = -1.
@@ -57,7 +59,8 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     // Exponents for inversions and square roots mod P
     uint256 constant EXP_INVERSE_FP =
         0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD45; // P - 2
-    uint256 constant EXP_SQRT_FP = 0xC19139CB84C680A6E14116DA060561765E05AA45A1C72A34F082305B61F3F52; // (P + 1) / 4;
+    uint256 constant EXP_SQRT_FP =
+        0xC19139CB84C680A6E14116DA060561765E05AA45A1C72A34F082305B61F3F52; // (P + 1) / 4;
 
     // Groth16 alpha point in G1
     uint256 constant ALPHA_X =
@@ -207,11 +210,11 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param hint A hint which of two possible signs to pick in the equation.
     /// @return x0 The real part of the square root.
     /// @return x1 The imaginary part of the square root.
-    function sqrt_Fp2(uint256 a0, uint256 a1, bool hint)
-        internal
-        view
-        returns (uint256 x0, uint256 x1)
-    {
+    function sqrt_Fp2(
+        uint256 a0,
+        uint256 a1,
+        bool hint
+    ) internal view returns (uint256 x0, uint256 x1) {
         // If this square root reverts there is no solution in Fp2.
         uint256 d = sqrt_Fp(addmod(mulmod(a0, a0, P), mulmod(a1, a1, P), P));
         if (hint) {
@@ -224,8 +227,8 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
         // Check result to make sure we found a root.
         // Note: this also fails if a0 or a1 is not reduced.
         if (
-            a0 != addmod(mulmod(x0, x0, P), negate(mulmod(x1, x1, P)), P)
-                || a1 != mulmod(2, mulmod(x0, x1, P), P)
+            a0 != addmod(mulmod(x0, x0, P), negate(mulmod(x1, x1, P)), P) ||
+            a1 != mulmod(2, mulmod(x0, x1, P), P)
         ) {
             revert ProofInvalid();
         }
@@ -238,7 +241,10 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param x The X coordinate in Fp.
     /// @param y The Y coordinate in Fp.
     /// @return c The compresed point (x with one signal bit).
-    function compress_g1(uint256 x, uint256 y) internal view returns (uint256 c) {
+    function compress_g1(
+        uint256 x,
+        uint256 y
+    ) internal view returns (uint256 c) {
         if (x >= P || y >= P) {
             // G1 point not in field.
             revert ProofInvalid();
@@ -266,7 +272,9 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param c The compresed point (x with one signal bit).
     /// @return x The X coordinate in Fp.
     /// @return y The Y coordinate in Fp.
-    function decompress_g1(uint256 c) internal view returns (uint256 x, uint256 y) {
+    function decompress_g1(
+        uint256 c
+    ) internal view returns (uint256 x, uint256 y) {
         // Note that X = 0 is not on the curve since 0³ + 3 = 3 is not a square.
         // so we can use it to represent the point at infinity.
         if (c == 0) {
@@ -301,11 +309,12 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param y1 The imaginary part of the Y coordinate.
     /// @return c0 The first half of the compresed point (x0 with two signal bits).
     /// @return c1 The second half of the compressed point (x1 unmodified).
-    function compress_g2(uint256 x0, uint256 x1, uint256 y0, uint256 y1)
-        internal
-        view
-        returns (uint256 c0, uint256 c1)
-    {
+    function compress_g2(
+        uint256 x0,
+        uint256 x1,
+        uint256 y0,
+        uint256 y1
+    ) internal view returns (uint256 c0, uint256 c1) {
         if (x0 >= P || x1 >= P || y0 >= P || y1 >= P) {
             // G2 point not in field.
             revert ProofInvalid();
@@ -323,16 +332,26 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
             uint256 n3ab = mulmod(mulmod(x0, x1, P), P - 3, P);
             uint256 a_3 = mulmod(mulmod(x0, x0, P), x0, P);
             uint256 b_3 = mulmod(mulmod(x1, x1, P), x1, P);
-            y0_pos = addmod(FRACTION_27_82_FP, addmod(a_3, mulmod(n3ab, x1, P), P), P);
-            y1_pos = negate(addmod(FRACTION_3_82_FP, addmod(b_3, mulmod(n3ab, x0, P), P), P));
+            y0_pos = addmod(
+                FRACTION_27_82_FP,
+                addmod(a_3, mulmod(n3ab, x1, P), P),
+                P
+            );
+            y1_pos = negate(
+                addmod(FRACTION_3_82_FP, addmod(b_3, mulmod(n3ab, x0, P), P), P)
+            );
         }
 
         // Determine hint bit
         // If this sqrt fails the x coordinate is not on the curve.
         bool hint;
         {
-            uint256 d = sqrt_Fp(addmod(mulmod(y0_pos, y0_pos, P), mulmod(y1_pos, y1_pos, P), P));
-            hint = !isSquare_Fp(mulmod(addmod(y0_pos, d, P), FRACTION_1_2_FP, P));
+            uint256 d = sqrt_Fp(
+                addmod(mulmod(y0_pos, y0_pos, P), mulmod(y1_pos, y1_pos, P), P)
+            );
+            hint = !isSquare_Fp(
+                mulmod(addmod(y0_pos, d, P), FRACTION_1_2_FP, P)
+            );
         }
 
         // Recover y
@@ -360,11 +379,10 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @return x1 The imaginary poart of the X coordinate.
     /// @return y0 The real part of the Y coordinate.
     /// @return y1 The imaginary part of the Y coordinate.
-    function decompress_g2(uint256 c0, uint256 c1)
-        internal
-        view
-        returns (uint256 x0, uint256 x1, uint256 y0, uint256 y1)
-    {
+    function decompress_g2(
+        uint256 c0,
+        uint256 c1
+    ) internal view returns (uint256 x0, uint256 x1, uint256 y0, uint256 y1) {
         // Note that X = (0, 0) is not on the curve since 0³ + 3/(9 + i) is not a square.
         // so we can use it to represent the point at infinity.
         if (c0 == 0 && c1 == 0) {
@@ -385,7 +403,9 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
         uint256 b_3 = mulmod(mulmod(x1, x1, P), x1, P);
 
         y0 = addmod(FRACTION_27_82_FP, addmod(a_3, mulmod(n3ab, x1, P), P), P);
-        y1 = negate(addmod(FRACTION_3_82_FP, addmod(b_3, mulmod(n3ab, x0, P), P), P));
+        y1 = negate(
+            addmod(FRACTION_3_82_FP, addmod(b_3, mulmod(n3ab, x0, P), P), P)
+        );
 
         // Note: sqrt_Fp2 reverts if there is no solution, i.e. the point is not on the curve.
         // Note: (X³ + 3/(9 + i)) is irreducible in Fp2, so y can not be zero.
@@ -404,11 +424,9 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param input The public inputs. These are elements of the scalar field Fr.
     /// @return x The X coordinate of the resulting G1 point.
     /// @return y The Y coordinate of the resulting G1 point.
-    function publicInputMSM(uint256[4] calldata input)
-        internal
-        view
-        returns (uint256 x, uint256 y)
-    {
+    function publicInputMSM(
+        uint256[4] calldata input
+    ) internal view returns (uint256 x, uint256 y) {
         // Note: The ECMUL precompile does not reject unreduced values, so we check this.
         // Note: Unrolling this loop does not cost much extra in code-size, the bulk of the
         //       code-size is in the PUB_ constants.
@@ -428,29 +446,53 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
             s := calldataload(input)
             mstore(add(g, 0x40), s)
             success := and(success, lt(s, R))
-            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
-            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
+            success := and(
+                success,
+                staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40)
+            )
+            success := and(
+                success,
+                staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40)
+            )
             mstore(g, PUB_1_X)
             mstore(add(g, 0x20), PUB_1_Y)
             s := calldataload(add(input, 32))
             mstore(add(g, 0x40), s)
             success := and(success, lt(s, R))
-            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
-            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
+            success := and(
+                success,
+                staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40)
+            )
+            success := and(
+                success,
+                staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40)
+            )
             mstore(g, PUB_2_X)
             mstore(add(g, 0x20), PUB_2_Y)
             s := calldataload(add(input, 64))
             mstore(add(g, 0x40), s)
             success := and(success, lt(s, R))
-            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
-            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
+            success := and(
+                success,
+                staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40)
+            )
+            success := and(
+                success,
+                staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40)
+            )
             mstore(g, PUB_3_X)
             mstore(add(g, 0x20), PUB_3_Y)
             s := calldataload(add(input, 96))
             mstore(add(g, 0x40), s)
             success := and(success, lt(s, R))
-            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
-            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
+            success := and(
+                success,
+                staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40)
+            )
+            success := and(
+                success,
+                staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40)
+            )
             x := mload(f)
             y := mload(add(f, 0x20))
         }
@@ -468,13 +510,16 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// verifyProof. I.e. Groth16 points (A, B, C) encoded as in EIP-197.
     /// @return compressed The compressed proof. Elements are in the same order as for
     /// verifyCompressedProof. I.e. points (A, B, C) in compressed format.
-    function compressProof(uint256[8] calldata proof)
-        public
-        view
-        returns (uint256[4] memory compressed)
-    {
+    function compressProof(
+        uint256[8] calldata proof
+    ) public view returns (uint256[4] memory compressed) {
         compressed[0] = compress_g1(proof[0], proof[1]);
-        (compressed[2], compressed[1]) = compress_g2(proof[3], proof[2], proof[5], proof[4]);
+        (compressed[2], compressed[1]) = compress_g2(
+            proof[3],
+            proof[2],
+            proof[5],
+            proof[4]
+        );
         compressed[3] = compress_g1(proof[6], proof[7]);
     }
 
@@ -487,13 +532,15 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// matching the output of compressProof.
     /// @param input the public input field elements in the scalar field Fr.
     /// Elements must be reduced.
-    function verifyCompressedProof(uint256[4] calldata compressedProof, uint256[4] calldata input)
-        public
-        view
-    {
+    function verifyCompressedProof(
+        uint256[4] calldata compressedProof,
+        uint256[4] calldata input
+    ) public view {
         (uint256 Ax, uint256 Ay) = decompress_g1(compressedProof[0]);
-        (uint256 Bx0, uint256 Bx1, uint256 By0, uint256 By1) =
-            decompress_g2(compressedProof[2], compressedProof[1]);
+        (uint256 Bx0, uint256 Bx1, uint256 By0, uint256 By1) = decompress_g2(
+            compressedProof[2],
+            compressedProof[1]
+        );
         (uint256 Cx, uint256 Cy) = decompress_g1(compressedProof[3]);
         (uint256 Lx, uint256 Ly) = publicInputMSM(input);
 
@@ -534,7 +581,14 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
         bool success;
         uint256[1] memory output;
         assembly ("memory-safe") {
-            success := staticcall(gas(), PRECOMPILE_VERIFY, pairings, 0x300, output, 0x20)
+            success := staticcall(
+                gas(),
+                PRECOMPILE_VERIFY,
+                pairings,
+                0x300,
+                output,
+                0x20
+            )
         }
         if (!success || output[0] != 1) {
             // Either proof or verification key invalid.
@@ -552,7 +606,10 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// of compressProof.
     /// @param input the public input field elements in the scalar field Fr.
     /// Elements must be reduced.
-    function verifyProof(uint256[8] calldata proof, uint256[4] calldata input) public view {
+    function verifyProof(
+        uint256[8] calldata proof,
+        uint256[4] calldata input
+    ) public view {
         (uint256 x, uint256 y) = publicInputMSM(input);
 
         // Note: The precompile expects the F2 coefficients in big-endian order.

--- a/src/test/SemaphoreVerifier16.sol
+++ b/src/test/SemaphoreVerifier16.sol
@@ -36,10 +36,8 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     //     t = 4965661367192848881
     //     P = 36⋅t⁴ + 36⋅t³ + 24⋅t² + 6⋅t + 1
     //     R = 36⋅t⁴ + 36⋅t³ + 18⋅t² + 6⋅t + 1
-    uint256 constant P =
-        0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47;
-    uint256 constant R =
-        0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
+    uint256 constant P = 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47;
+    uint256 constant R = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001;
 
     // Extension field Fp2 = Fp[i] / (i² + 1)
     // Note: This is the complex extension field of Fp with i² = -1.
@@ -59,8 +57,7 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     // Exponents for inversions and square roots mod P
     uint256 constant EXP_INVERSE_FP =
         0x30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD45; // P - 2
-    uint256 constant EXP_SQRT_FP =
-        0xC19139CB84C680A6E14116DA060561765E05AA45A1C72A34F082305B61F3F52; // (P + 1) / 4;
+    uint256 constant EXP_SQRT_FP = 0xC19139CB84C680A6E14116DA060561765E05AA45A1C72A34F082305B61F3F52; // (P + 1) / 4;
 
     // Groth16 alpha point in G1
     uint256 constant ALPHA_X =
@@ -210,11 +207,11 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param hint A hint which of two possible signs to pick in the equation.
     /// @return x0 The real part of the square root.
     /// @return x1 The imaginary part of the square root.
-    function sqrt_Fp2(
-        uint256 a0,
-        uint256 a1,
-        bool hint
-    ) internal view returns (uint256 x0, uint256 x1) {
+    function sqrt_Fp2(uint256 a0, uint256 a1, bool hint)
+        internal
+        view
+        returns (uint256 x0, uint256 x1)
+    {
         // If this square root reverts there is no solution in Fp2.
         uint256 d = sqrt_Fp(addmod(mulmod(a0, a0, P), mulmod(a1, a1, P), P));
         if (hint) {
@@ -227,8 +224,8 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
         // Check result to make sure we found a root.
         // Note: this also fails if a0 or a1 is not reduced.
         if (
-            a0 != addmod(mulmod(x0, x0, P), negate(mulmod(x1, x1, P)), P) ||
-            a1 != mulmod(2, mulmod(x0, x1, P), P)
+            a0 != addmod(mulmod(x0, x0, P), negate(mulmod(x1, x1, P)), P)
+                || a1 != mulmod(2, mulmod(x0, x1, P), P)
         ) {
             revert ProofInvalid();
         }
@@ -241,10 +238,7 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param x The X coordinate in Fp.
     /// @param y The Y coordinate in Fp.
     /// @return c The compresed point (x with one signal bit).
-    function compress_g1(
-        uint256 x,
-        uint256 y
-    ) internal view returns (uint256 c) {
+    function compress_g1(uint256 x, uint256 y) internal view returns (uint256 c) {
         if (x >= P || y >= P) {
             // G1 point not in field.
             revert ProofInvalid();
@@ -272,9 +266,7 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param c The compresed point (x with one signal bit).
     /// @return x The X coordinate in Fp.
     /// @return y The Y coordinate in Fp.
-    function decompress_g1(
-        uint256 c
-    ) internal view returns (uint256 x, uint256 y) {
+    function decompress_g1(uint256 c) internal view returns (uint256 x, uint256 y) {
         // Note that X = 0 is not on the curve since 0³ + 3 = 3 is not a square.
         // so we can use it to represent the point at infinity.
         if (c == 0) {
@@ -309,12 +301,11 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param y1 The imaginary part of the Y coordinate.
     /// @return c0 The first half of the compresed point (x0 with two signal bits).
     /// @return c1 The second half of the compressed point (x1 unmodified).
-    function compress_g2(
-        uint256 x0,
-        uint256 x1,
-        uint256 y0,
-        uint256 y1
-    ) internal view returns (uint256 c0, uint256 c1) {
+    function compress_g2(uint256 x0, uint256 x1, uint256 y0, uint256 y1)
+        internal
+        view
+        returns (uint256 c0, uint256 c1)
+    {
         if (x0 >= P || x1 >= P || y0 >= P || y1 >= P) {
             // G2 point not in field.
             revert ProofInvalid();
@@ -332,26 +323,16 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
             uint256 n3ab = mulmod(mulmod(x0, x1, P), P - 3, P);
             uint256 a_3 = mulmod(mulmod(x0, x0, P), x0, P);
             uint256 b_3 = mulmod(mulmod(x1, x1, P), x1, P);
-            y0_pos = addmod(
-                FRACTION_27_82_FP,
-                addmod(a_3, mulmod(n3ab, x1, P), P),
-                P
-            );
-            y1_pos = negate(
-                addmod(FRACTION_3_82_FP, addmod(b_3, mulmod(n3ab, x0, P), P), P)
-            );
+            y0_pos = addmod(FRACTION_27_82_FP, addmod(a_3, mulmod(n3ab, x1, P), P), P);
+            y1_pos = negate(addmod(FRACTION_3_82_FP, addmod(b_3, mulmod(n3ab, x0, P), P), P));
         }
 
         // Determine hint bit
         // If this sqrt fails the x coordinate is not on the curve.
         bool hint;
         {
-            uint256 d = sqrt_Fp(
-                addmod(mulmod(y0_pos, y0_pos, P), mulmod(y1_pos, y1_pos, P), P)
-            );
-            hint = !isSquare_Fp(
-                mulmod(addmod(y0_pos, d, P), FRACTION_1_2_FP, P)
-            );
+            uint256 d = sqrt_Fp(addmod(mulmod(y0_pos, y0_pos, P), mulmod(y1_pos, y1_pos, P), P));
+            hint = !isSquare_Fp(mulmod(addmod(y0_pos, d, P), FRACTION_1_2_FP, P));
         }
 
         // Recover y
@@ -379,10 +360,11 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @return x1 The imaginary poart of the X coordinate.
     /// @return y0 The real part of the Y coordinate.
     /// @return y1 The imaginary part of the Y coordinate.
-    function decompress_g2(
-        uint256 c0,
-        uint256 c1
-    ) internal view returns (uint256 x0, uint256 x1, uint256 y0, uint256 y1) {
+    function decompress_g2(uint256 c0, uint256 c1)
+        internal
+        view
+        returns (uint256 x0, uint256 x1, uint256 y0, uint256 y1)
+    {
         // Note that X = (0, 0) is not on the curve since 0³ + 3/(9 + i) is not a square.
         // so we can use it to represent the point at infinity.
         if (c0 == 0 && c1 == 0) {
@@ -403,9 +385,7 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
         uint256 b_3 = mulmod(mulmod(x1, x1, P), x1, P);
 
         y0 = addmod(FRACTION_27_82_FP, addmod(a_3, mulmod(n3ab, x1, P), P), P);
-        y1 = negate(
-            addmod(FRACTION_3_82_FP, addmod(b_3, mulmod(n3ab, x0, P), P), P)
-        );
+        y1 = negate(addmod(FRACTION_3_82_FP, addmod(b_3, mulmod(n3ab, x0, P), P), P));
 
         // Note: sqrt_Fp2 reverts if there is no solution, i.e. the point is not on the curve.
         // Note: (X³ + 3/(9 + i)) is irreducible in Fp2, so y can not be zero.
@@ -424,9 +404,11 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// @param input The public inputs. These are elements of the scalar field Fr.
     /// @return x The X coordinate of the resulting G1 point.
     /// @return y The Y coordinate of the resulting G1 point.
-    function publicInputMSM(
-        uint256[4] calldata input
-    ) internal view returns (uint256 x, uint256 y) {
+    function publicInputMSM(uint256[4] calldata input)
+        internal
+        view
+        returns (uint256 x, uint256 y)
+    {
         // Note: The ECMUL precompile does not reject unreduced values, so we check this.
         // Note: Unrolling this loop does not cost much extra in code-size, the bulk of the
         //       code-size is in the PUB_ constants.
@@ -446,53 +428,29 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
             s := calldataload(input)
             mstore(add(g, 0x40), s)
             success := and(success, lt(s, R))
-            success := and(
-                success,
-                staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40)
-            )
-            success := and(
-                success,
-                staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40)
-            )
+            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
+            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
             mstore(g, PUB_1_X)
             mstore(add(g, 0x20), PUB_1_Y)
             s := calldataload(add(input, 32))
             mstore(add(g, 0x40), s)
             success := and(success, lt(s, R))
-            success := and(
-                success,
-                staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40)
-            )
-            success := and(
-                success,
-                staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40)
-            )
+            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
+            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
             mstore(g, PUB_2_X)
             mstore(add(g, 0x20), PUB_2_Y)
             s := calldataload(add(input, 64))
             mstore(add(g, 0x40), s)
             success := and(success, lt(s, R))
-            success := and(
-                success,
-                staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40)
-            )
-            success := and(
-                success,
-                staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40)
-            )
+            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
+            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
             mstore(g, PUB_3_X)
             mstore(add(g, 0x20), PUB_3_Y)
             s := calldataload(add(input, 96))
             mstore(add(g, 0x40), s)
             success := and(success, lt(s, R))
-            success := and(
-                success,
-                staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40)
-            )
-            success := and(
-                success,
-                staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40)
-            )
+            success := and(success, staticcall(gas(), PRECOMPILE_MUL, g, 0x60, g, 0x40))
+            success := and(success, staticcall(gas(), PRECOMPILE_ADD, f, 0x80, f, 0x40))
             x := mload(f)
             y := mload(add(f, 0x20))
         }
@@ -510,16 +468,13 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// verifyProof. I.e. Groth16 points (A, B, C) encoded as in EIP-197.
     /// @return compressed The compressed proof. Elements are in the same order as for
     /// verifyCompressedProof. I.e. points (A, B, C) in compressed format.
-    function compressProof(
-        uint256[8] calldata proof
-    ) public view returns (uint256[4] memory compressed) {
+    function compressProof(uint256[8] calldata proof)
+        public
+        view
+        returns (uint256[4] memory compressed)
+    {
         compressed[0] = compress_g1(proof[0], proof[1]);
-        (compressed[2], compressed[1]) = compress_g2(
-            proof[3],
-            proof[2],
-            proof[5],
-            proof[4]
-        );
+        (compressed[2], compressed[1]) = compress_g2(proof[3], proof[2], proof[5], proof[4]);
         compressed[3] = compress_g1(proof[6], proof[7]);
     }
 
@@ -532,15 +487,13 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// matching the output of compressProof.
     /// @param input the public input field elements in the scalar field Fr.
     /// Elements must be reduced.
-    function verifyCompressedProof(
-        uint256[4] calldata compressedProof,
-        uint256[4] calldata input
-    ) public view {
+    function verifyCompressedProof(uint256[4] calldata compressedProof, uint256[4] calldata input)
+        public
+        view
+    {
         (uint256 Ax, uint256 Ay) = decompress_g1(compressedProof[0]);
-        (uint256 Bx0, uint256 Bx1, uint256 By0, uint256 By1) = decompress_g2(
-            compressedProof[2],
-            compressedProof[1]
-        );
+        (uint256 Bx0, uint256 Bx1, uint256 By0, uint256 By1) =
+            decompress_g2(compressedProof[2], compressedProof[1]);
         (uint256 Cx, uint256 Cy) = decompress_g1(compressedProof[3]);
         (uint256 Lx, uint256 Ly) = publicInputMSM(input);
 
@@ -581,14 +534,7 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
         bool success;
         uint256[1] memory output;
         assembly ("memory-safe") {
-            success := staticcall(
-                gas(),
-                PRECOMPILE_VERIFY,
-                pairings,
-                0x300,
-                output,
-                0x20
-            )
+            success := staticcall(gas(), PRECOMPILE_VERIFY, pairings, 0x300, output, 0x20)
         }
         if (!success || output[0] != 1) {
             // Either proof or verification key invalid.
@@ -606,10 +552,7 @@ contract SemaphoreVerifier is ISemaphoreVerifier {
     /// of compressProof.
     /// @param input the public input field elements in the scalar field Fr.
     /// Elements must be reduced.
-    function verifyProof(
-        uint256[8] calldata proof,
-        uint256[4] calldata input
-    ) public view {
+    function verifyProof(uint256[8] calldata proof, uint256[4] calldata input) public view {
         (uint256 x, uint256 y) = publicInputMSM(input);
 
         // Note: The precompile expects the F2 coefficients in big-endian order.

--- a/src/test/WorldIDTest.sol
+++ b/src/test/WorldIDTest.sol
@@ -14,7 +14,6 @@ contract WorldIDTest is Test {
     ///                                TEST DATA                                ///
     ///////////////////////////////////////////////////////////////////////////////
 
-    Vm internal hevm = Vm(HEVM_ADDRESS);
     address internal nullAddress = address(0x0);
     address internal thisAddress = address(this);
 
@@ -26,8 +25,11 @@ contract WorldIDTest is Test {
     ///
     /// @param target The target at which to make the call.
     /// @param callData The ABI-encoded call to a function.
-    function assertCallSucceedsOn(address target, bytes memory callData) public {
-        (bool status,) = target.call(callData);
+    function assertCallSucceedsOn(
+        address target,
+        bytes memory callData
+    ) public {
+        (bool status, ) = target.call(callData);
         assert(status);
     }
 
@@ -51,7 +53,7 @@ contract WorldIDTest is Test {
     /// @param target The target at which to make the call.
     /// @param callData The ABI-encoded call to a function.
     function assertCallFailsOn(address target, bytes memory callData) public {
-        (bool status,) = target.call(callData);
+        (bool status, ) = target.call(callData);
         assert(!status);
     }
 
@@ -76,7 +78,9 @@ contract WorldIDTest is Test {
     /// @param reason The string reason for the revert.
     ///
     /// @return data The ABI encoding of the revert.
-    function encodeStringRevert(string memory reason) public pure returns (bytes memory data) {
+    function encodeStringRevert(
+        string memory reason
+    ) public pure returns (bytes memory data) {
         return abi.encodeWithSignature("Error(string)", reason);
     }
 }

--- a/src/test/WorldIDTest.sol
+++ b/src/test/WorldIDTest.sol
@@ -25,11 +25,8 @@ contract WorldIDTest is Test {
     ///
     /// @param target The target at which to make the call.
     /// @param callData The ABI-encoded call to a function.
-    function assertCallSucceedsOn(
-        address target,
-        bytes memory callData
-    ) public {
-        (bool status, ) = target.call(callData);
+    function assertCallSucceedsOn(address target, bytes memory callData) public {
+        (bool status,) = target.call(callData);
         assert(status);
     }
 
@@ -53,7 +50,7 @@ contract WorldIDTest is Test {
     /// @param target The target at which to make the call.
     /// @param callData The ABI-encoded call to a function.
     function assertCallFailsOn(address target, bytes memory callData) public {
-        (bool status, ) = target.call(callData);
+        (bool status,) = target.call(callData);
         assert(!status);
     }
 
@@ -78,9 +75,7 @@ contract WorldIDTest is Test {
     /// @param reason The string reason for the revert.
     ///
     /// @return data The ABI encoding of the revert.
-    function encodeStringRevert(
-        string memory reason
-    ) public pure returns (bytes memory data) {
+    function encodeStringRevert(string memory reason) public pure returns (bytes memory data) {
         return abi.encodeWithSignature("Error(string)", reason);
     }
 }

--- a/src/test/identity-manager/WorldIDIdentityManagerSemaphoreVerification.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerSemaphoreVerification.t.sol
@@ -17,9 +17,7 @@ import {WorldIDIdentityManagerImplV3 as ManagerImplV3} from "../../WorldIDIdenti
 /// @author Worldcoin
 /// @dev This test suite tests both the proxy and the functionality of the underlying implementation
 ///      so as to test everything in the context of how it will be deployed.
-contract WorldIDIdentityManagerSemaphoreVerification is
-    WorldIDIdentityManagerTest
-{
+contract WorldIDIdentityManagerSemaphoreVerification is WorldIDIdentityManagerTest {
     error ProofInvalid();
 
     /// @notice Checks that the proof validates properly with the correct inputs.
@@ -27,8 +25,7 @@ contract WorldIDIdentityManagerSemaphoreVerification is
         // Setup
         SemaphoreVerifier actualSemaphoreVerifier = new SemaphoreVerifier();
 
-        uint256[4] memory compressedProof = actualSemaphoreVerifier
-            .compressProof(inclusionProof);
+        uint256[4] memory compressedProof = actualSemaphoreVerifier.compressProof(inclusionProof);
 
         // Use IdentityManager V3
         makeNewIdentityManagerV3(
@@ -113,10 +110,9 @@ contract WorldIDIdentityManagerSemaphoreVerification is
     }
 
     /// @notice Checks that the proof validates properly with the correct inputs.
-    function testProofVerificationWithIncorrectProof(
-        uint8 actualTreeDepth,
-        uint256[8] memory prf
-    ) public {
+    function testProofVerificationWithIncorrectProof(uint8 actualTreeDepth, uint256[8] memory prf)
+        public
+    {
         ISemaphoreVerifier actualSemaphoreVerifier = new SemaphoreVerifier();
         // Setup
         vm.assume(SemaphoreTreeDepthValidator.validate(actualTreeDepth));
@@ -141,13 +137,11 @@ contract WorldIDIdentityManagerSemaphoreVerification is
         );
 
         // Custom error elector doesn't work for low level calls, use string instead
-        bytes memory errorData = abi.encodeWithSelector(
-            SemaphoreVerifier.ProofInvalid.selector
-        );
+        bytes memory errorData = abi.encodeWithSelector(SemaphoreVerifier.ProofInvalid.selector);
 
         // Test
         vm.expectRevert(errorData);
-        (bool success, ) = identityManagerAddress.call(verifyProofCallData);
+        (bool success,) = identityManagerAddress.call(verifyProofCallData);
         assertTrue(success, "expectRevert: call did not revert");
     }
 
@@ -176,7 +170,8 @@ contract WorldIDIdentityManagerSemaphoreVerification is
         // 2) Make the public input array with at least one element >= R.
         //    R is 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
         //    Just reuse the constant from your contract if it's public; otherwise hardcode it.
-        uint256 unreducedSignalHash = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001; // >= R
+        uint256 unreducedSignalHash =
+            0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001; // >= R
 
         bytes memory verifyProofCallData = abi.encodeCall(
             ManagerImplV3.verifyCompressedProof,
@@ -193,9 +188,7 @@ contract WorldIDIdentityManagerSemaphoreVerification is
         assertCallFailsOn(
             identityManagerAddress,
             verifyProofCallData,
-            abi.encodeWithSelector(
-                SemaphoreVerifier.PublicInputNotInField.selector
-            )
+            abi.encodeWithSelector(SemaphoreVerifier.PublicInputNotInField.selector)
         );
     }
 }

--- a/src/test/identity-manager/WorldIDIdentityManagerSemaphoreVerification.t.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerSemaphoreVerification.t.sol
@@ -17,97 +17,80 @@ import {WorldIDIdentityManagerImplV3 as ManagerImplV3} from "../../WorldIDIdenti
 /// @author Worldcoin
 /// @dev This test suite tests both the proxy and the functionality of the underlying implementation
 ///      so as to test everything in the context of how it will be deployed.
-contract WorldIDIdentityManagerSemaphoreVerification is WorldIDIdentityManagerTest {
+contract WorldIDIdentityManagerSemaphoreVerification is
+    WorldIDIdentityManagerTest
+{
+    error ProofInvalid();
+
     /// @notice Checks that the proof validates properly with the correct inputs.
-    function testProofVerificationWithCompressedProof(
-        uint8 actualTreeDepth,
-        uint256 nullifierHash,
-        uint256 signalHash,
-        uint256 externalNullifierHash,
-        uint256[4] memory prf // Compressed proof is 4 uints
-    ) public {
+    function testProofVerificationWithCompressedProof() public {
         // Setup
-        ISemaphoreVerifier actualSemaphoreVerifier = new SimpleSemaphoreVerifier();
-        vm.assume(SemaphoreTreeDepthValidator.validate(actualTreeDepth));
-        vm.assume(prf[0] != 0);
-        // SimpleVerifier expects that proof[0] % 2 == 0 for compressed proof
-        // The opposite is true for non-compressed proofs
-        // This checks that the correct logical path in IdentityManager is taken
-        vm.assume(prf[0] % 2 == 0);
-        uint256[8] memory prfExpanded = [prf[0], prf[1], prf[2], prf[3], 0, 0, 0, 0];
+        SemaphoreVerifier actualSemaphoreVerifier = new SemaphoreVerifier();
+
+        uint256[4] memory compressedProof = actualSemaphoreVerifier
+            .compressProof(inclusionProof);
 
         // Use IdentityManager V3
         makeNewIdentityManagerV3(
-            actualTreeDepth,
-            insertionPreRoot,
+            treeDepth,
+            inclusionRoot,
             defaultInsertVerifiers,
             defaultDeletionVerifiers,
             defaultUpdateVerifiers,
             actualSemaphoreVerifier
         );
+        // expanded proof
         bytes memory verifyProofCallData = abi.encodeCall(
-            ManagerImplV1.verifyProof,
-            (insertionPreRoot, nullifierHash, signalHash, externalNullifierHash, prfExpanded)
+            ManagerImplV3.verifyCompressedProof,
+            (
+                inclusionRoot,
+                inclusionSignalHash,
+                inclusionNullifierHash,
+                inclusionExternalNullifierHash,
+                compressedProof
+            )
         );
 
         // Test
         assertCallSucceedsOn(identityManagerAddress, verifyProofCallData);
 
-        bytes memory verifyCompressedProofCallData = abi.encodeCall(
-            ManagerImplV3.verifyCompressedProof,
-            (insertionPreRoot, nullifierHash, signalHash, externalNullifierHash, prf)
+        // 0 padded proof
+        uint256[8] memory zeroPaddedProof = [
+            compressedProof[0],
+            compressedProof[1],
+            compressedProof[2],
+            compressedProof[3],
+            0,
+            0,
+            0,
+            0
+        ];
+
+        bytes memory verifyProofCallData2 = abi.encodeCall(
+            ManagerImplV3.verifyProof,
+            (
+                inclusionRoot,
+                inclusionSignalHash,
+                inclusionNullifierHash,
+                inclusionExternalNullifierHash,
+                zeroPaddedProof
+            )
         );
 
         // Test
-        assertCallSucceedsOn(identityManagerAddress, verifyCompressedProofCallData);
+        assertCallSucceedsOn(identityManagerAddress, verifyProofCallData2);
     }
 
     /// @notice Checks that the proof validates properly with the correct inputs.
     function testProofVerificationWithCorrectInputs(
-        uint8 actualTreeDepth,
         uint256 nullifierHash,
         uint256 signalHash,
-        uint256 externalNullifierHash,
-        uint256[8] memory prf
+        uint256 externalNullifierHash
     ) public {
         // Setup
-        ISemaphoreVerifier actualSemaphoreVerifier = new SimpleSemaphoreVerifier();
-        vm.assume(SemaphoreTreeDepthValidator.validate(actualTreeDepth));
-        vm.assume(prf[0] != 0);
-        // SimpleVerifier expects that proof[0] % 2 != 0 for non-compressed proof
-        // This checks that the correct logical path in IdentityManager is taken
-        vm.assume(prf[0] % 2 != 0);
+        ISemaphoreVerifier actualSemaphoreVerifier = new SemaphoreVerifier();
         makeNewIdentityManager(
-            actualTreeDepth,
-            insertionPreRoot,
-            defaultInsertVerifiers,
-            defaultDeletionVerifiers,
-            defaultUpdateVerifiers,
-            actualSemaphoreVerifier
-        );
-        bytes memory verifyProofCallData = abi.encodeCall(
-            ManagerImplV1.verifyProof,
-            (insertionPreRoot, nullifierHash, signalHash, externalNullifierHash, prf)
-        );
-
-        // Test
-        assertCallSucceedsOn(identityManagerAddress, verifyProofCallData);
-    }
-
-    /// @notice Checks that the proof validates properly with the correct inputs.
-    function testProofVerificationWithInorrectProof(
-        uint8 actualTreeDepth,
-        uint256 nullifierHash,
-        uint256 signalHash,
-        uint256 externalNullifierHash,
-        uint256[8] memory prf
-    ) public {
-        // Setup
-        ISemaphoreVerifier actualSemaphoreVerifier = new SimpleSemaphoreVerifier();
-        vm.assume(SemaphoreTreeDepthValidator.validate(actualTreeDepth));
-        vm.assume(prf[0] % 2 == 0);
-        makeNewIdentityManager(
-            actualTreeDepth,
+            treeDepth,
             inclusionRoot,
             defaultInsertVerifiers,
             defaultDeletionVerifiers,
@@ -115,22 +98,31 @@ contract WorldIDIdentityManagerSemaphoreVerification is WorldIDIdentityManagerTe
             actualSemaphoreVerifier
         );
         bytes memory verifyProofCallData = abi.encodeCall(
-            ManagerImplV1.verifyProof,
-            (inclusionRoot, nullifierHash, signalHash, externalNullifierHash, prf)
+            ManagerImplV3.verifyProof,
+            (
+                inclusionRoot,
+                inclusionSignalHash,
+                inclusionNullifierHash,
+                inclusionExternalNullifierHash,
+                inclusionProof
+            )
         );
 
-        vm.expectRevert("Semaphore__InvalidProof()");
         // Test
-        assertCallFailsOn(identityManagerAddress, verifyProofCallData);
+        assertCallSucceedsOn(identityManagerAddress, verifyProofCallData);
     }
 
     /// @notice Checks that the proof validates properly with the correct inputs.
-    function testOptimizedProofVerificationWithCorrectInputs(uint256[8] memory prf) public {
-        // Setup
+    function testProofVerificationWithIncorrectProof(
+        uint8 actualTreeDepth,
+        uint256[8] memory prf
+    ) public {
         ISemaphoreVerifier actualSemaphoreVerifier = new SemaphoreVerifier();
-        vm.assume(prf[0] != 0);
-        makeNewIdentityManager(
-            treeDepth,
+        // Setup
+        vm.assume(SemaphoreTreeDepthValidator.validate(actualTreeDepth));
+        vm.assume(prf[0] != inclusionProof[0]);
+        makeNewIdentityManagerV3(
+            actualTreeDepth,
             inclusionRoot,
             defaultInsertVerifiers,
             defaultDeletionVerifiers,
@@ -144,11 +136,66 @@ contract WorldIDIdentityManagerSemaphoreVerification is WorldIDIdentityManagerTe
                 inclusionSignalHash,
                 inclusionNullifierHash,
                 inclusionExternalNullifierHash,
-                inclusionProof
+                prf
+            )
+        );
+
+        // Custom error elector doesn't work for low level calls, use string instead
+        bytes memory errorData = abi.encodeWithSelector(
+            SemaphoreVerifier.ProofInvalid.selector
+        );
+
+        // Test
+        vm.expectRevert(errorData);
+        (bool success, ) = identityManagerAddress.call(verifyProofCallData);
+        assertTrue(success, "expectRevert: call did not revert");
+    }
+
+    /// @notice Checks that the verifyProof will fail with incorrect inputs.
+    function testProofVerificationWithIncorrectInputs() public {
+        // Setup
+        ISemaphoreVerifier actualSemaphoreVerifier = new SemaphoreVerifier();
+        makeNewIdentityManagerV3(
+            treeDepth,
+            inclusionRoot,
+            defaultInsertVerifiers,
+            defaultDeletionVerifiers,
+            defaultUpdateVerifiers,
+            actualSemaphoreVerifier
+        );
+
+        // 1) Use all-zero compressed proof so that decompress() does not revert
+        //    A=0 => G1 infinity, B=0 => G2 infinity, C=0 => G1 infinity
+        uint256[4] memory compressedProof = [
+            uint256(0), // A in G1 compressed = 0 => point at infinity
+            0, // B in G2 compressed part #1
+            0, // B in G2 compressed part #2
+            0 // C in G1 compressed = 0 => point at infinity
+        ];
+
+        // 2) Make the public input array with at least one element >= R.
+        //    R is 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+        //    Just reuse the constant from your contract if it's public; otherwise hardcode it.
+        uint256 unreducedSignalHash = 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001; // >= R
+
+        bytes memory verifyProofCallData = abi.encodeCall(
+            ManagerImplV3.verifyCompressedProof,
+            (
+                inclusionRoot, // make sure the root is correct, as there is separate validation logic for it compared to other public inputs
+                unreducedSignalHash,
+                inclusionNullifierHash,
+                inclusionExternalNullifierHash,
+                compressedProof
             )
         );
 
         // Test
-        assertCallSucceedsOn(identityManagerAddress, verifyProofCallData);
+        assertCallFailsOn(
+            identityManagerAddress,
+            verifyProofCallData,
+            abi.encodeWithSelector(
+                SemaphoreVerifier.PublicInputNotInField.selector
+            )
+        );
     }
 }

--- a/src/test/identity-manager/WorldIDIdentityManagerTest.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerTest.sol
@@ -82,9 +82,17 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
         0x18cb13df3e79b9f847a1494d0a2e6f3cc0041d9cae7e5ccb8cd1852ecdc4af58;
     uint256 internal constant deletionPostRoot =
         0x82fcf94594d7363636338e2c29242cc77e3d04f36c8ad64d294d2ab4d251708;
-    bytes packedDeletionIndices = abi.encodePacked(
-        uint32(0), uint32(2), uint32(4), uint32(6), uint32(8), uint32(10), uint32(12), uint32(14)
-    );
+    bytes packedDeletionIndices =
+        abi.encodePacked(
+            uint32(0),
+            uint32(2),
+            uint32(4),
+            uint32(6),
+            uint32(8),
+            uint32(10),
+            uint32(12),
+            uint32(14)
+        );
     uint32 deletionBatchSize = 8;
     uint256[8] deletionProof;
 
@@ -201,10 +209,10 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
             semaphoreVerifier
         );
 
-        hevm.label(address(this), "Sender");
-        hevm.label(identityManagerAddress, "IdentityManager");
-        hevm.label(managerImplV2Address, "ManagerImplementationV2");
-        hevm.label(managerImplV1Address, "ManagerImplementationV1");
+        vm.label(address(this), "Sender");
+        vm.label(identityManagerAddress, "IdentityManager");
+        vm.label(managerImplV2Address, "ManagerImplementationV2");
+        vm.label(managerImplV1Address, "ManagerImplementationV1");
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -240,20 +248,31 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
             )
         );
 
-        identityManager = new IdentityManager(managerImplV1Address, initCallData);
+        identityManager = new IdentityManager(
+            managerImplV1Address,
+            initCallData
+        );
         identityManagerAddress = address(identityManager);
 
         // creates Manager Impl V2, which will be used for tests
         managerImplV2 = new ManagerImplV2();
         managerImplV2Address = address(managerImplV2);
 
-        bytes memory initCallV2 = abi.encodeCall(ManagerImplV2.initializeV2, (deletionVerifiers));
+        bytes memory initCallV2 = abi.encodeCall(
+            ManagerImplV2.initializeV2,
+            (deletionVerifiers)
+        );
         bytes memory upgradeCall = abi.encodeCall(
-            UUPSUpgradeable.upgradeToAndCall, (address(managerImplV2Address), initCallV2)
+            UUPSUpgradeable.upgradeToAndCall,
+            (address(managerImplV2Address), initCallV2)
         );
 
         // Test
-        assertCallSucceedsOn(identityManagerAddress, upgradeCall, new bytes(0x0));
+        assertCallSucceedsOn(
+            identityManagerAddress,
+            upgradeCall,
+            new bytes(0x0)
+        );
     }
 
     /// @notice Initialises a new identity manager using the provided information.
@@ -285,27 +304,40 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
             )
         );
 
-        identityManager = new IdentityManager(managerImplV1Address, initCallData);
+        identityManager = new IdentityManager(
+            managerImplV1Address,
+            initCallData
+        );
         identityManagerAddress = address(identityManager);
 
         // creates Manager Impl V2, which will be used for tests
         managerImplV2 = new ManagerImplV2();
         managerImplV2Address = address(managerImplV2);
 
-        bytes memory initCallV2 = abi.encodeCall(ManagerImplV2.initializeV2, (deletionVerifiers));
+        bytes memory initCallV2 = abi.encodeCall(
+            ManagerImplV2.initializeV2,
+            (deletionVerifiers)
+        );
         bytes memory upgradeCallV2 = abi.encodeCall(
-            UUPSUpgradeable.upgradeToAndCall, (address(managerImplV2Address), initCallV2)
+            UUPSUpgradeable.upgradeToAndCall,
+            (address(managerImplV2Address), initCallV2)
         );
 
         // Test
-        assertCallSucceedsOn(identityManagerAddress, upgradeCallV2, new bytes(0x0));
+        assertCallSucceedsOn(
+            identityManagerAddress,
+            upgradeCallV2,
+            new bytes(0x0)
+        );
 
         // creates Manager Impl V3
         managerImplV3 = new ManagerImplV3();
         managerImplV3Address = address(managerImplV3);
 
-        bytes memory upgradeCallV3 =
-            abi.encodeCall(UUPSUpgradeable.upgradeTo, (address(managerImplV3Address)));
+        bytes memory upgradeCallV3 = abi.encodeCall(
+            UUPSUpgradeable.upgradeTo,
+            (address(managerImplV3Address))
+        );
 
         // Test
         assertCallSucceedsOn(identityManagerAddress, upgradeCallV3);
@@ -320,7 +352,10 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     ///
     /// @custom:reverts string If any batch size exceeds 1000.
     /// @custom:reverts string If `batchSizes` is empty.
-    function makeNewIdentityManager(uint256 actualPreRoot, uint256[] calldata batchSizes) public {
+    function makeNewIdentityManager(
+        uint256 actualPreRoot,
+        uint256[] calldata batchSizes
+    ) public {
         (
             VerifierLookupTable insertVerifiers,
             VerifierLookupTable deletionVerifiers,
@@ -353,7 +388,9 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     /// @custom:reverts VerifierExists If `batchSizes` contains a duplicate.
     /// @custom:reverts string If any batch size exceeds 1000.
     /// @custom:reverts string If `batchSizes` is empty.
-    function makeVerifierLookupTables(uint256[] memory batchSizes)
+    function makeVerifierLookupTables(
+        uint256[] memory batchSizes
+    )
         public
         returns (
             VerifierLookupTable insertVerifiers,
@@ -389,7 +426,10 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     function makeUninitIdentityManager() public {
         managerImplV2 = new ManagerImplV2();
         managerImplV2Address = address(managerImplV2);
-        identityManager = new IdentityManager(managerImplV2Address, new bytes(0x0));
+        identityManager = new IdentityManager(
+            managerImplV2Address,
+            new bytes(0x0)
+        );
         identityManagerAddress = address(identityManager);
     }
 
@@ -406,7 +446,9 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     /// @param arr The array to clone.
     ///
     /// @return out The clone of `arr`.
-    function cloneArray(uint256[] memory arr) public pure returns (uint256[] memory out) {
+    function cloneArray(
+        uint256[] memory arr
+    ) public pure returns (uint256[] memory out) {
         out = new uint256[](arr.length);
         for (uint256 i = 0; i < arr.length; ++i) {
             out[i] = arr[i];
@@ -423,7 +465,10 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     ///
     /// @return preparedIdents The conversion of `idents` to the proper type.
     /// @return actualProof The conversion of `prf` to the proper type.
-    function prepareInsertIdentitiesTestCase(uint128[] memory idents, uint128[8] memory prf)
+    function prepareInsertIdentitiesTestCase(
+        uint128[] memory idents,
+        uint128[8] memory prf
+    )
         public
         pure
         returns (uint256[] memory preparedIdents, uint256[8] memory actualProof)
@@ -436,7 +481,16 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
             preparedIdents[i] = uint256(idents[i]);
         }
 
-        actualProof = [uint256(prf[0]), prf[1], prf[2], prf[3], prf[4], prf[5], prf[6], prf[7]];
+        actualProof = [
+            uint256(prf[0]),
+            prf[1],
+            prf[2],
+            prf[3],
+            prf[4],
+            prf[5],
+            prf[6],
+            prf[7]
+        ];
     }
 
     /// @notice Prepares a verifier test case.
@@ -446,11 +500,18 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     /// @param prf The generated proof terms to convert.
     ///
     /// @return actualProof The conversion of `prf` to the proper type.
-    function prepareDeleteIdentitiesTestCase(uint128[8] memory prf)
-        public
-        pure
-        returns (uint256[8] memory actualProof)
-    {
-        actualProof = [uint256(prf[0]), prf[1], prf[2], prf[3], prf[4], prf[5], prf[6], prf[7]];
+    function prepareDeleteIdentitiesTestCase(
+        uint128[8] memory prf
+    ) public pure returns (uint256[8] memory actualProof) {
+        actualProof = [
+            uint256(prf[0]),
+            prf[1],
+            prf[2],
+            prf[3],
+            prf[4],
+            prf[5],
+            prf[6],
+            prf[7]
+        ];
     }
 }

--- a/src/test/identity-manager/WorldIDIdentityManagerTest.sol
+++ b/src/test/identity-manager/WorldIDIdentityManagerTest.sol
@@ -82,17 +82,9 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
         0x18cb13df3e79b9f847a1494d0a2e6f3cc0041d9cae7e5ccb8cd1852ecdc4af58;
     uint256 internal constant deletionPostRoot =
         0x82fcf94594d7363636338e2c29242cc77e3d04f36c8ad64d294d2ab4d251708;
-    bytes packedDeletionIndices =
-        abi.encodePacked(
-            uint32(0),
-            uint32(2),
-            uint32(4),
-            uint32(6),
-            uint32(8),
-            uint32(10),
-            uint32(12),
-            uint32(14)
-        );
+    bytes packedDeletionIndices = abi.encodePacked(
+        uint32(0), uint32(2), uint32(4), uint32(6), uint32(8), uint32(10), uint32(12), uint32(14)
+    );
     uint32 deletionBatchSize = 8;
     uint256[8] deletionProof;
 
@@ -248,31 +240,20 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
             )
         );
 
-        identityManager = new IdentityManager(
-            managerImplV1Address,
-            initCallData
-        );
+        identityManager = new IdentityManager(managerImplV1Address, initCallData);
         identityManagerAddress = address(identityManager);
 
         // creates Manager Impl V2, which will be used for tests
         managerImplV2 = new ManagerImplV2();
         managerImplV2Address = address(managerImplV2);
 
-        bytes memory initCallV2 = abi.encodeCall(
-            ManagerImplV2.initializeV2,
-            (deletionVerifiers)
-        );
+        bytes memory initCallV2 = abi.encodeCall(ManagerImplV2.initializeV2, (deletionVerifiers));
         bytes memory upgradeCall = abi.encodeCall(
-            UUPSUpgradeable.upgradeToAndCall,
-            (address(managerImplV2Address), initCallV2)
+            UUPSUpgradeable.upgradeToAndCall, (address(managerImplV2Address), initCallV2)
         );
 
         // Test
-        assertCallSucceedsOn(
-            identityManagerAddress,
-            upgradeCall,
-            new bytes(0x0)
-        );
+        assertCallSucceedsOn(identityManagerAddress, upgradeCall, new bytes(0x0));
     }
 
     /// @notice Initialises a new identity manager using the provided information.
@@ -304,40 +285,27 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
             )
         );
 
-        identityManager = new IdentityManager(
-            managerImplV1Address,
-            initCallData
-        );
+        identityManager = new IdentityManager(managerImplV1Address, initCallData);
         identityManagerAddress = address(identityManager);
 
         // creates Manager Impl V2, which will be used for tests
         managerImplV2 = new ManagerImplV2();
         managerImplV2Address = address(managerImplV2);
 
-        bytes memory initCallV2 = abi.encodeCall(
-            ManagerImplV2.initializeV2,
-            (deletionVerifiers)
-        );
+        bytes memory initCallV2 = abi.encodeCall(ManagerImplV2.initializeV2, (deletionVerifiers));
         bytes memory upgradeCallV2 = abi.encodeCall(
-            UUPSUpgradeable.upgradeToAndCall,
-            (address(managerImplV2Address), initCallV2)
+            UUPSUpgradeable.upgradeToAndCall, (address(managerImplV2Address), initCallV2)
         );
 
         // Test
-        assertCallSucceedsOn(
-            identityManagerAddress,
-            upgradeCallV2,
-            new bytes(0x0)
-        );
+        assertCallSucceedsOn(identityManagerAddress, upgradeCallV2, new bytes(0x0));
 
         // creates Manager Impl V3
         managerImplV3 = new ManagerImplV3();
         managerImplV3Address = address(managerImplV3);
 
-        bytes memory upgradeCallV3 = abi.encodeCall(
-            UUPSUpgradeable.upgradeTo,
-            (address(managerImplV3Address))
-        );
+        bytes memory upgradeCallV3 =
+            abi.encodeCall(UUPSUpgradeable.upgradeTo, (address(managerImplV3Address)));
 
         // Test
         assertCallSucceedsOn(identityManagerAddress, upgradeCallV3);
@@ -352,10 +320,7 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     ///
     /// @custom:reverts string If any batch size exceeds 1000.
     /// @custom:reverts string If `batchSizes` is empty.
-    function makeNewIdentityManager(
-        uint256 actualPreRoot,
-        uint256[] calldata batchSizes
-    ) public {
+    function makeNewIdentityManager(uint256 actualPreRoot, uint256[] calldata batchSizes) public {
         (
             VerifierLookupTable insertVerifiers,
             VerifierLookupTable deletionVerifiers,
@@ -388,9 +353,7 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     /// @custom:reverts VerifierExists If `batchSizes` contains a duplicate.
     /// @custom:reverts string If any batch size exceeds 1000.
     /// @custom:reverts string If `batchSizes` is empty.
-    function makeVerifierLookupTables(
-        uint256[] memory batchSizes
-    )
+    function makeVerifierLookupTables(uint256[] memory batchSizes)
         public
         returns (
             VerifierLookupTable insertVerifiers,
@@ -426,10 +389,7 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     function makeUninitIdentityManager() public {
         managerImplV2 = new ManagerImplV2();
         managerImplV2Address = address(managerImplV2);
-        identityManager = new IdentityManager(
-            managerImplV2Address,
-            new bytes(0x0)
-        );
+        identityManager = new IdentityManager(managerImplV2Address, new bytes(0x0));
         identityManagerAddress = address(identityManager);
     }
 
@@ -446,9 +406,7 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     /// @param arr The array to clone.
     ///
     /// @return out The clone of `arr`.
-    function cloneArray(
-        uint256[] memory arr
-    ) public pure returns (uint256[] memory out) {
+    function cloneArray(uint256[] memory arr) public pure returns (uint256[] memory out) {
         out = new uint256[](arr.length);
         for (uint256 i = 0; i < arr.length; ++i) {
             out[i] = arr[i];
@@ -465,10 +423,7 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     ///
     /// @return preparedIdents The conversion of `idents` to the proper type.
     /// @return actualProof The conversion of `prf` to the proper type.
-    function prepareInsertIdentitiesTestCase(
-        uint128[] memory idents,
-        uint128[8] memory prf
-    )
+    function prepareInsertIdentitiesTestCase(uint128[] memory idents, uint128[8] memory prf)
         public
         pure
         returns (uint256[] memory preparedIdents, uint256[8] memory actualProof)
@@ -481,16 +436,7 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
             preparedIdents[i] = uint256(idents[i]);
         }
 
-        actualProof = [
-            uint256(prf[0]),
-            prf[1],
-            prf[2],
-            prf[3],
-            prf[4],
-            prf[5],
-            prf[6],
-            prf[7]
-        ];
+        actualProof = [uint256(prf[0]), prf[1], prf[2], prf[3], prf[4], prf[5], prf[6], prf[7]];
     }
 
     /// @notice Prepares a verifier test case.
@@ -500,18 +446,11 @@ contract WorldIDIdentityManagerTest is WorldIDTest {
     /// @param prf The generated proof terms to convert.
     ///
     /// @return actualProof The conversion of `prf` to the proper type.
-    function prepareDeleteIdentitiesTestCase(
-        uint128[8] memory prf
-    ) public pure returns (uint256[8] memory actualProof) {
-        actualProof = [
-            uint256(prf[0]),
-            prf[1],
-            prf[2],
-            prf[3],
-            prf[4],
-            prf[5],
-            prf[6],
-            prf[7]
-        ];
+    function prepareDeleteIdentitiesTestCase(uint128[8] memory prf)
+        public
+        pure
+        returns (uint256[8] memory actualProof)
+    {
+        actualProof = [uint256(prf[0]), prf[1], prf[2], prf[3], prf[4], prf[5], prf[6], prf[7]];
     }
 }

--- a/src/test/router/WorldIDRouterTest.sol
+++ b/src/test/router/WorldIDRouterTest.sol
@@ -30,9 +30,7 @@ contract WorldIDRouterTest is WorldIDTest {
     /// @notice Emitted when a group is enabled in the router.
     ///
     /// @param initialGroupIdentityManager The address of the identity manager to be used for the first group
-    event GroupIdentityManagerRouterImplInitialized(
-        IWorldID initialGroupIdentityManager
-    );
+    event GroupIdentityManagerRouterImplInitialized(IWorldID initialGroupIdentityManager);
 
     ///////////////////////////////////////////////////////////////////////////////
     ///                            TEST ORCHESTRATION                           ///
@@ -66,10 +64,7 @@ contract WorldIDRouterTest is WorldIDTest {
 
         emit GroupIdentityManagerRouterImplInitialized(initialGroupAddress);
 
-        bytes memory initCallData = abi.encodeCall(
-            RouterImpl.initialize,
-            (initialGroupAddress)
-        );
+        bytes memory initCallData = abi.encodeCall(RouterImpl.initialize, (initialGroupAddress));
 
         router = new Router(routerImplAddress, initCallData);
         routerAddress = address(router);

--- a/src/test/router/WorldIDRouterTest.sol
+++ b/src/test/router/WorldIDRouterTest.sol
@@ -30,7 +30,9 @@ contract WorldIDRouterTest is WorldIDTest {
     /// @notice Emitted when a group is enabled in the router.
     ///
     /// @param initialGroupIdentityManager The address of the identity manager to be used for the first group
-    event GroupIdentityManagerRouterImplInitialized(IWorldID initialGroupIdentityManager);
+    event GroupIdentityManagerRouterImplInitialized(
+        IWorldID initialGroupIdentityManager
+    );
 
     ///////////////////////////////////////////////////////////////////////////////
     ///                            TEST ORCHESTRATION                           ///
@@ -43,9 +45,9 @@ contract WorldIDRouterTest is WorldIDTest {
         makeNewRouter(thisWorldID);
 
         // Label the addresses for better errors.
-        hevm.label(thisAddress, "Sender");
-        hevm.label(routerAddress, "Router");
-        hevm.label(routerImplAddress, "RouterImplementation");
+        vm.label(thisAddress, "Sender");
+        vm.label(routerAddress, "Router");
+        vm.label(routerImplAddress, "RouterImplementation");
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -64,7 +66,10 @@ contract WorldIDRouterTest is WorldIDTest {
 
         emit GroupIdentityManagerRouterImplInitialized(initialGroupAddress);
 
-        bytes memory initCallData = abi.encodeCall(RouterImpl.initialize, (initialGroupAddress));
+        bytes memory initCallData = abi.encodeCall(
+            RouterImpl.initialize,
+            (initialGroupAddress)
+        );
 
         router = new Router(routerImplAddress, initCallData);
         routerAddress = address(router);

--- a/src/test/verifier-lookup-table/VerifierLookupTableTest.sol
+++ b/src/test/verifier-lookup-table/VerifierLookupTableTest.sol
@@ -32,8 +32,8 @@ contract VerifierLookupTableTest is WorldIDTest {
         makeNewLUT(defaultBatchSize);
 
         // Label the addresses for better errors.
-        hevm.label(thisAddress, "Sender");
-        hevm.label(lookupTableAddress, "LUT");
+        vm.label(thisAddress, "Sender");
+        vm.label(lookupTableAddress, "LUT");
     }
 
     ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added real verifiers and tests to test all edge cases (`ProofInvalid` and `PublicInputNotInField`). 